### PR TITLE
improve adler32 perf

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -703,7 +703,7 @@ const adler = (): CRCV => {
     p(d) {
       // closures have awful performance
       let n = a, m = b;
-      const l = d.length;
+      const l = d.length | 0;
       for (let i = 0; i != l;) {
         const e = Math.min(i + 2655, l);
         for (; i < e; ++i) m += n += d[i];


### PR DESCRIPTION
casts length variable into i32

|| 1gb | 500mb |
|--|--| --|
| before | 1134ms | 553ms |
| after | 845ms | 412ms |