### PR TITLE
Fix a tiny typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ const zipped = fflate.zipSync({
 // |-> other
 // |   |-> tmp.txt
 // myImageData.bmp
-// superTinyFile.bin
+// superTinyFile.png
 
 // When decompressing, folders are not nested; all filepaths are fully
 // written out in the keys. For example, the return value may be:


### PR DESCRIPTION
In the example, there's a `'superTinyFile.png': [aPNGFile, { level: 0 }]` line. But later it refers to the file as `superTinyFile.bin` that's most likely supposed to stay a `.png`.