### PR TITLE
Check if index is negative before incrementing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,11 @@ const hMap = ((cd: Uint8Array, mb: number, r: 0 | 1) => {
   // u16 "map": index -> # of codes with bit length = index
   const l = new u16(mb);
   // length of cd must be 288 (total # of codes)
-  for (; i < s; ++i) ++l[cd[i] - 1];
+  for (; i < s; ++i) {
+    if (cd[i] - 1 >= 0) {
+      ++l[cd[i] - 1];
+    }
+  }
   // u16 "map": index -> minimum code for bit length = index
   const le = new u16(mb);
   for (i = 0; i < mb; ++i) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ const hMap = ((cd: Uint8Array, mb: number, r: 0 | 1) => {
   const l = new u16(mb);
   // length of cd must be 288 (total # of codes)
   for (; i < s; ++i) {
-    if (cd[i] - 1 >= 0) {
+    if (cd[i] > 0) {
       ++l[cd[i] - 1];
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,9 +67,7 @@ const hMap = ((cd: Uint8Array, mb: number, r: 0 | 1) => {
   const l = new u16(mb);
   // length of cd must be 288 (total # of codes)
   for (; i < s; ++i) {
-    if (cd[i] > 0) {
-      ++l[cd[i] - 1];
-    }
+    if (cd[i]) ++l[cd[i] - 1];
   }
   // u16 "map": index -> minimum code for bit length = index
   const le = new u16(mb);


### PR DESCRIPTION
This one is related to https://github.com/101arrowz/fflate/issues/71 :) After the `setTimeout` issue was sorted I found another minor one.

In the `hMap` function there is a moment where the program may try to access a negative index. Although in Node.js and browsers that does not raise an error, in QML it does raise a `TypeError`. Good thing is: after this fix it all works over there too. 

I was not able to run the complete fflate test suite in my machine, so hopefully this works fine. The actual behaviour of the code does not change here, I just changed the code path a little bit to avoid attempting to access a negative index.

AH! And for reference, this is the error I got while trying to run `yarn test` on my machine:

```
 FAIL  compression  "image"
    Cannot find module '/Users/beatrizmachado/Projects/fflate/lib/index.cjs'. Please verify that the package.json has a valid "main" entry
```