### PR TITLE
refactor: add semicolon at the end of self-invoking function

### DIFF
--- a/scripts/buildUMD.ts
+++ b/scripts/buildUMD.ts
@@ -32,7 +32,7 @@ minify(src, opts).then(async out => {
   const res = "!function(f){typeof module!='undefined'&&typeof exports=='object'?module.exports=f():typeof define!='undefined'&&define.amd?define(f):(typeof self!='undefined'?self:this).fflate=f()}(function(){var _e={};" +
     out.code!.replace(/exports\.(.*) = void 0;\n/, '').replace(/exports\./g, '_e.').replace(/require\("\.\/node-worker\.cjs"\)/,
     "(typeof module!='undefined'&&typeof exports=='object'?function(_f){" + nodeWkrOut + 'return _f}:function(_f){' + wkrOut + 'return _f})({})'
-  ) + 'return _e})';
+  ) + 'return _e});';
   if (!existsSync(p('umd'))) mkdirSync(p('umd'));
   writeFileSync(p('umd', 'index.js'), res);
 });


### PR DESCRIPTION
Safely concatenate. Ref: https://github.com/airbnb/javascript/issues/44#issuecomment-13063933
Actual error case: https://github.com/Tampermonkey/tampermonkey/issues/595