### PR TITLE
Fix typescript definitions under moduleResutions: node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "node": {
         "import": "./esm/index.mjs",
         "require": "./lib/node.cjs"
@@ -20,10 +21,12 @@
       "require": "./lib/index.cjs"
     },
     "./node": {
+      "types": "./lib/index.d.ts",
       "import": "./esm/index.mjs",
       "require": "./lib/node.cjs"
     },
     "./browser": {
+      "types": "./lib/index.d.ts",
       "import": "./esm/browser.js",
       "require": "./lib/browser.cjs"
     }


### PR DESCRIPTION
Typescript 4.7 introduced new module resolution. Under this mode it does look into exports field to find types. This disallows it from finding typescript definition of this module. This MR fixes it.