### PR TITLE
Fix types ESM module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.8.0",
   "description": "High performance (de)compression in an 8kB package",
   "main": "./lib/index.cjs",
-  "module": "./esm/browser.mjs",
-  "types": "./lib/index.d.cts",
+  "module": "./esm/browser.js",
+  "types": "./lib/index.d.ts",
   "unpkg": "./umd/index.js",
   "jsdelivr": "./umd/index.js",
   "browser": {
@@ -13,19 +13,43 @@
   "exports": {
     ".": {
       "node": {
-        "import": "./esm/index.mjs",
-        "require": "./lib/node.cjs"
+        "import": {
+          "types": "./esm/index.d.mts",
+          "default": "./esm/index.mjs"
+        },
+        "require": {
+          "types": "./lib/node.d.cts",
+          "default": "./lib/node.cjs"
+        }
       },
-      "import": "./esm/browser.mjs",
-      "require": "./lib/index.cjs"
+      "import": {
+        "types": "./esm/browser.d.ts",
+        "default": "./esm/browser.js"
+      },
+      "require": {
+        "types": "./lib/browser.d.cts",
+        "default": "./lib/browser.cjs"
+      }
     },
     "./node": {
-      "import": "./esm/index.mjs",
-      "require": "./lib/node.cjs"
+      "import": {
+        "types": "./esm/index.d.mts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./lib/node.d.cts",
+        "default": "./lib/node.cjs"
+      }
     },
     "./browser": {
-      "import": "./esm/browser.mjs",
-      "require": "./lib/browser.cjs"
+      "import": {
+        "types": "./esm/browser.d.ts",
+        "default": "./esm/browser.js"
+      },
+      "require": {
+        "types": "./lib/browser.d.cts",
+        "default": "./lib/browser.cjs"
+      }
     }
   },
   "targets": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.8.0",
   "description": "High performance (de)compression in an 8kB package",
   "main": "./lib/index.cjs",
-  "module": "./esm/browser.js",
-  "types": "./lib/index.d.ts",
+  "module": "./esm/browser.mjs",
+  "types": "./lib/index.d.cts",
   "unpkg": "./umd/index.js",
   "jsdelivr": "./umd/index.js",
   "browser": {
@@ -12,22 +12,19 @@
   },
   "exports": {
     ".": {
-      "types": "./lib/index.d.ts",
       "node": {
         "import": "./esm/index.mjs",
         "require": "./lib/node.cjs"
       },
-      "import": "./esm/browser.js",
+      "import": "./esm/browser.mjs",
       "require": "./lib/index.cjs"
     },
     "./node": {
-      "types": "./lib/index.d.ts",
       "import": "./esm/index.mjs",
       "require": "./lib/node.cjs"
     },
     "./browser": {
-      "types": "./lib/index.d.ts",
-      "import": "./esm/browser.js",
+      "import": "./esm/browser.mjs",
       "require": "./lib/browser.cjs"
     }
   },

--- a/scripts/rewriteBuilds.ts
+++ b/scripts/rewriteBuilds.ts
@@ -8,6 +8,7 @@ const lib = readFileSync(libIndex, 'utf-8')
   .replace(atClass, pure)
   .replace(esModule, '')
   .replace(/exports\.(.*) = void 0;\n/, '');
+const libTypes = readFileSync(join(libDir, 'index.d.ts'), 'utf-8');
 
 writeFileSync(libIndex, lib);
 const esmDir = join(__dirname, '..', 'esm');
@@ -22,18 +23,23 @@ const wk = readFileSync(esmWK, 'utf-8'),
 writeFileSync(join(libDir, 'worker.cjs'), readFileSync(join(libDir, 'worker.js'), 'utf-8').replace(esModule, ''));
 writeFileSync(join(libDir, 'node-worker.cjs'), readFileSync(join(libDir, 'node-worker.js'), 'utf-8').replace(esModule, ''));
 unlinkSync(esmIndex), unlinkSync(esmWK), unlinkSync(esmNWK), unlinkSync(libIndex), unlinkSync(libWK), unlinkSync(libNWK);
-unlinkSync(join(libDir, 'worker.d.ts')), unlinkSync(join(libDir, 'node-worker.d.ts'));
+unlinkSync(join(libDir, 'index.d.ts')), unlinkSync(join(libDir, 'worker.d.ts')), unlinkSync(join(libDir, 'node-worker.d.ts'));
 const workerImport = /import (.*) from '\.\/node-worker';/;
 const workerRequire = /var (.*) = require\("\.\/node-worker"\);/;
 const defaultExport = /export default/;
 writeFileSync(join(esmDir, 'index.mjs'), "import { createRequire } from 'module';\nvar require = createRequire('/');\n" + esm.replace(workerImport, name => nwk.replace(defaultExport, `var ${name.slice(7, name.indexOf(' ', 8))} =`)));
-writeFileSync(join(esmDir, 'browser.js'), esm.replace(workerImport, name => wk.replace(defaultExport, `var ${name.slice(7, name.indexOf(' ', 8))} =`)));
+writeFileSync(join(esmDir, 'index.d.mts'), libTypes);
+writeFileSync(join(esmDir, 'browser.mjs'), esm.replace(workerImport, name => wk.replace(defaultExport, `var ${name.slice(7, name.indexOf(' ', 8))} =`)));
+writeFileSync(join(esmDir, 'browser.d.mts'), libTypes);
 writeFileSync(join(libDir, 'node.cjs'), lib.replace(workerRequire, name => {
   name = name.slice(4, name.indexOf(' ', 5));
   return nwk.replace(defaultExport, `var ${name} = {};\n${name}["default"] =`)
 }));
+writeFileSync(join(libDir, 'node.d.cts'), libTypes);
 writeFileSync(join(libDir, 'browser.cjs'), lib.replace(workerRequire, name => {
   name = name.slice(4, name.indexOf(' ', 5));
   return wk.replace(defaultExport, `var ${name} = {};\n${name}["default"] =`)
 }));
+writeFileSync(join(libDir, 'browser.d.cts'), libTypes);
 writeFileSync(join(libDir, 'index.cjs'), lib.replace(workerRequire, name => `var ${name.slice(4, name.indexOf(' ', 5))} = require("./node-worker.cjs");`));
+writeFileSync(join(libDir, 'index.d.cts'), libTypes);

--- a/scripts/rewriteBuilds.ts
+++ b/scripts/rewriteBuilds.ts
@@ -1,7 +1,7 @@
-import { readFileSync, writeFileSync, unlinkSync, renameSync } from 'fs';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 const atClass = /\/\*\* \@class \*\//g, pure = '/*#__PURE__*/';
-const esModule = /exports.__esModule = true;\n/;
+const esModule = /exports\.__esModule = true;\n/;
 const libDir = join(__dirname, '..', 'lib');
 const libIndex = join(libDir, 'index.js');
 const lib = readFileSync(libIndex, 'utf-8')
@@ -24,13 +24,13 @@ writeFileSync(join(libDir, 'worker.cjs'), readFileSync(join(libDir, 'worker.js')
 writeFileSync(join(libDir, 'node-worker.cjs'), readFileSync(join(libDir, 'node-worker.js'), 'utf-8').replace(esModule, ''));
 unlinkSync(esmIndex), unlinkSync(esmWK), unlinkSync(esmNWK), unlinkSync(libIndex), unlinkSync(libWK), unlinkSync(libNWK);
 unlinkSync(join(libDir, 'index.d.ts')), unlinkSync(join(libDir, 'worker.d.ts')), unlinkSync(join(libDir, 'node-worker.d.ts'));
-const workerImport = /import (.*) from '\.\/node-worker';/;
-const workerRequire = /var (.*) = require\("\.\/node-worker"\);/;
+const workerImport = /import (.*?) from '\.\/node-worker';/;
+const workerRequire = /var (.*?) = require\("\.\/node-worker"\);/;
 const defaultExport = /export default/;
 writeFileSync(join(esmDir, 'index.mjs'), "import { createRequire } from 'module';\nvar require = createRequire('/');\n" + esm.replace(workerImport, name => nwk.replace(defaultExport, `var ${name.slice(7, name.indexOf(' ', 8))} =`)));
 writeFileSync(join(esmDir, 'index.d.mts'), libTypes);
-writeFileSync(join(esmDir, 'browser.mjs'), esm.replace(workerImport, name => wk.replace(defaultExport, `var ${name.slice(7, name.indexOf(' ', 8))} =`)));
-writeFileSync(join(esmDir, 'browser.d.mts'), libTypes);
+writeFileSync(join(esmDir, 'browser.js'), esm.replace(workerImport, name => wk.replace(defaultExport, `var ${name.slice(7, name.indexOf(' ', 8))} =`)));
+writeFileSync(join(esmDir, 'browser.d.ts'), libTypes);
 writeFileSync(join(libDir, 'node.cjs'), lib.replace(workerRequire, name => {
   name = name.slice(4, name.indexOf(' ', 5));
   return nwk.replace(defaultExport, `var ${name} = {};\n${name}["default"] =`)
@@ -42,4 +42,4 @@ writeFileSync(join(libDir, 'browser.cjs'), lib.replace(workerRequire, name => {
 }));
 writeFileSync(join(libDir, 'browser.d.cts'), libTypes);
 writeFileSync(join(libDir, 'index.cjs'), lib.replace(workerRequire, name => `var ${name.slice(4, name.indexOf(' ', 5))} = require("./node-worker.cjs");`));
-writeFileSync(join(libDir, 'index.d.cts'), libTypes);
+writeFileSync(join(libDir, 'index.d.ts'), libTypes);


### PR DESCRIPTION
"Are the types wrong?"  reveals that the ESM modules in this package are [masquerading as CJS](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md) from a type perspective (https://arethetypeswrong.github.io/?p=fflate%400.8.0):

![image](https://github.com/101arrowz/fflate/assets/693755/355392fb-6936-41fd-bc0d-49dfd268a585)

This PR fixes the situation by creating a separate declaration file per module [as recommended in the TypeScript documentation](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing):

> It’s important to note that the CommonJS entrypoint and the ES module entrypoint each needs its own declaration file, even if the contents are the same between them. Every declaration file is interpreted either as a CommonJS module or as an ES module, based on its file extension and the "type" field of the package.json, and this detected module kind must match the module kind that Node will detect for the corresponding JavaScript file for type checking to be correct. Attempting to use a single .d.ts file to type both an ES module entrypoint and a CommonJS entrypoint will cause TypeScript to think only one of those entrypoints exists, causing compiler errors for users of the package.

Creating a declaration file per module fixes the type module resolution and fixes the "Are the types wrong?" tests:

![image](https://github.com/101arrowz/fflate/assets/693755/23f9d2fa-f1c4-428f-b0e8-822be4d9f60c)

The resulting built files now all specify whether they are CJS or MJS with the corresponding file extension and each module now has a corresponding declaration file which absolves the need to explicitly list them in `package.json#exports`:

![image](https://github.com/101arrowz/fflate/assets/693755/dfa08e8c-eb2f-4e9d-937b-daa28a009b17)

