### PR TITLE
Optimize inner loop in inflt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -379,13 +379,9 @@ const inflt = (dat: Uint8Array, st: InflateState, buf?: Uint8Array, dict?: Uint8
           if (shift + bt < 0) err(3);
           for (; bt < dend; ++bt) buf[bt] = dict[shift + bt];
         }
-        for (; bt < end; bt += 4) {
+        for (; bt < end; bt++) {
           buf[bt] = buf[bt - dt];
-          buf[bt + 1] = buf[bt + 1 - dt];
-          buf[bt + 2] = buf[bt + 2 - dt];
-          buf[bt + 3] = buf[bt + 3 - dt];
         }
-        bt = end;
       }
     }
     st.l = lm, st.p = lpos, st.b = bt, st.f = final;


### PR DESCRIPTION
This made the processing pipeline in our application, which is currently dominated by inflt, 3% faster. So the effect on inflt itself might be a bit larger than that.

Note that I don't know much about deflate or compression algorithms in general or low-level JS optimization. To me, this looked like a loop unroll of which V8 couldn't take advantage, maybe because neither source nor target are 4-byte-aligned, or maybe it's just not smart enough.
The loop would write up to 3 bytes more than just from bt to end. I assumed this was just an artifact of the loop unroll, and not important since the bytes written in excess are overwritten in the next outer loop iteration.

I also tried a fastpath using TypedArray.copyWithin if end-dt <= bt, in the hope that would do a simple memmove, but it was slower.

I didn't run the tests yet (but it looked to me like there are no functional ones?). Also I did not find any proper benchmarks. I'm happy to run some if there's a benchmark suite that's easy to setup.
