### PR TITLE
Add Zip64 write support

### DIFF
--- a/docs/classes/AsyncZipDeflate.md
+++ b/docs/classes/AsyncZipDeflate.md
@@ -26,6 +26,7 @@ Asynchronous streaming DEFLATE compression for ZIP archives
 - [os](AsyncZipDeflate.md#os)
 - [size](AsyncZipDeflate.md#size)
 - [terminate](AsyncZipDeflate.md#terminate)
+- [zip64](AsyncZipDeflate.md#zip64)
 
 ### Methods
 
@@ -248,6 +249,21 @@ processed if you have clean-up logic.
 #### Implementation of
 
 [ZipInputFile](../interfaces/ZipInputFile.md).[terminate](../interfaces/ZipInputFile.md#terminate)
+
+___
+
+### zip64
+
+• `Optional` **zip64**: `boolean`
+
+Flag used to enforce the Zip64 format for Data Descriptor as described
+in PKZIP's APPNOTE.txt, section 4.3.9.2.
+Set this flag to `true` if you suspect your file will be larger than 4GB
+before or after compression.
+
+#### Implementation of
+
+[ZipInputFile](../interfaces/ZipInputFile.md).[zip64](../interfaces/ZipInputFile.md#zip64)
 
 ## Methods
 

--- a/docs/classes/ZipDeflate.md
+++ b/docs/classes/ZipDeflate.md
@@ -26,6 +26,7 @@ for better performance
 - [ondata](ZipDeflate.md#ondata)
 - [os](ZipDeflate.md#os)
 - [size](ZipDeflate.md#size)
+- [zip64](ZipDeflate.md#zip64)
 
 ### Methods
 
@@ -233,6 +234,21 @@ ZipDeflate or AsyncZipDeflate.
 #### Implementation of
 
 [ZipInputFile](../interfaces/ZipInputFile.md).[size](../interfaces/ZipInputFile.md#size)
+
+___
+
+### zip64
+
+• `Optional` **zip64**: `boolean`
+
+Flag used to enforce the Zip64 format for Data Descriptor as described
+in PKZIP's APPNOTE.txt, section 4.3.9.2.
+Set this flag to `true` if you suspect your file will be larger than 4GB
+before or after compression.
+
+#### Implementation of
+
+[ZipInputFile](../interfaces/ZipInputFile.md).[zip64](../interfaces/ZipInputFile.md#zip64)
 
 ## Methods
 

--- a/docs/classes/ZipPassThrough.md
+++ b/docs/classes/ZipPassThrough.md
@@ -24,6 +24,7 @@ A pass-through stream to keep data uncompressed in a ZIP archive.
 - [ondata](ZipPassThrough.md#ondata)
 - [os](ZipPassThrough.md#os)
 - [size](ZipPassThrough.md#size)
+- [zip64](ZipPassThrough.md#zip64)
 
 ### Methods
 
@@ -215,6 +216,21 @@ ZipDeflate or AsyncZipDeflate.
 #### Implementation of
 
 [ZipInputFile](../interfaces/ZipInputFile.md).[size](../interfaces/ZipInputFile.md#size)
+
+___
+
+### zip64
+
+• `Optional` **zip64**: `boolean`
+
+Flag used to enforce the Zip64 format for Data Descriptor as described
+in PKZIP's APPNOTE.txt, section 4.3.9.2.
+Set this flag to `true` if you suspect your file will be larger than 4GB
+before or after compression.
+
+#### Implementation of
+
+[ZipInputFile](../interfaces/ZipInputFile.md).[zip64](../interfaces/ZipInputFile.md#zip64)
 
 ## Methods
 

--- a/docs/interfaces/ZipInputFile.md
+++ b/docs/interfaces/ZipInputFile.md
@@ -30,6 +30,7 @@ A stream that can be used to create a file in a ZIP archive
 - [os](ZipInputFile.md#os)
 - [size](ZipInputFile.md#size)
 - [terminate](ZipInputFile.md#terminate)
+- [zip64](ZipInputFile.md#zip64)
 
 ## Properties
 
@@ -204,3 +205,14 @@ A method called when the stream is no longer needed, for clean-up
 purposes. This will not always be called after the stream completes,
 so you may wish to call this.terminate() after the final chunk is
 processed if you have clean-up logic.
+
+___
+
+### zip64
+
+• `Optional` **zip64**: `boolean`
+
+Flag used to enforce the Zip64 format for Data Descriptor as described
+in PKZIP's APPNOTE.txt, section 4.3.9.2.
+Set this flag to `true` if you suspect your file will be larger than 4GB
+before or after compression.

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ const fdeb = new u8([0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8,
 // code length index map
 const clim = new u8([16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15]);
 
+const f4 = 0xFFFF; // uint16 max value 65535 - 2 bytes of ones
+const f8 = 0xFFFFFFFF; // uint32 max value 4294967295 - 4 bytes of ones
+
 // get base, reverse index map from extra bits
 const freb = (eb: Uint8Array, start: number) => {
   const b = new u16(31);
@@ -733,9 +736,9 @@ const dflt = (dat: Uint8Array, lvl: number, plvl: number, pre: number, post: num
       st.h = head, st.p = prev, st.i = i, st.w = wi;
     }
   } else {
-    for (let i = st.w || 0; i < s + lst; i += 65535) {
+    for (let i = st.w || 0; i < s + lst; i += f4) {
       // end
-      let e = i + 65535;
+      let e = i + f4;
       if (e >= s) {
         // write final block
         w[(pos / 8) | 0] = lst;
@@ -1183,9 +1186,13 @@ const b4 = (d: Uint8Array, b: number) => (d[b] | (d[b + 1] << 8) | (d[b + 2] << 
 
 const b8 = (d: Uint8Array, b: number) => b4(d, b) + (b4(d, b + 4) * 4294967296);
 
-// write bytes
+// write bytes, works only for values <= uint32
 const wbytes = (d: Uint8Array, b: number, v: number) => {
   for (; v; ++b) d[b] = v, v >>>= 8;
+}
+
+const wbytes64 = (d: Uint8Array, b: number, v: number) => {
+  for (; v; v /= 256) v -= d[b++] = v % 256;
 }
 
 // gzip header
@@ -2704,16 +2711,23 @@ const dbf = (l: number) => l == 1 ? 3 : l < 6 ? 2 : l == 9 ? 1 : 0;
 const slzh = (d: Uint8Array, b: number) => b + 30 + b2(d, b + 26) + b2(d, b + 28);
 
 // read zip header
-const zh = (d: Uint8Array, b: number, z: boolean) => {
-  const fnl = b2(d, b + 28), fn = strFromU8(d.subarray(b + 46, b + 46 + fnl), !(b2(d, b + 8) & 2048)), es = b + 46 + fnl, bs = b4(d, b + 20);
-  const [sc, su, off] = z && bs == 4294967295 ? z64e(d, es) : [bs, b4(d, b + 24), b4(d, b + 42)];
-  return [b2(d, b + 10), sc, su, fn, es + b2(d, b + 30) + b2(d, b + 32), off] as const;
+const zh = (d: Uint8Array, b: number) => {
+  const fnl = b2(d, b + 28), fn = strFromU8(d.subarray(b + 46, b + 46 + fnl), !(b2(d, b + 8) & 2048)), es = b + 46 + fnl, exl = b2(d, b + 30);
+  let su = b4(d, b + 24), sc: number | undefined, lo: number | undefined;
+  if (su == f8) {
+    const ef = z64e(d, es, exl);
+    if (ef) su = ef(su, 4), sc = ef(sc, 12), lo = ef(lo, 20);
+  }
+  return [b2(d, b + 10), sc ?? b4(d, b + 20), su, fn, es + exl + b2(d, b + 32), lo ?? b4(d, b + 42)] as const;
 }
 
 // read zip64 extra field
-const z64e = (d: Uint8Array, b: number) => {
-  for (; b2(d, b) != 1; b += 4 + b2(d, b + 2));
-  return [b8(d, b + 12), b8(d, b + 4), b8(d, b + 20)] as const;
+const z64e = (d: Uint8Array, b: number, exl: number) => {
+  let e = b + exl, id: number, l: number;
+  for (; b < e; b += l + 4) {
+    id = b2(d, b), l = b2(d, b + 2);
+    if (id == 1) return <T>(v: T, o: 4 | 12 | 20) => l > o ? b8(d, b + o) : v;
+  }
 }
 
 // zip header file
@@ -2725,7 +2739,7 @@ const exfl = (ex?: ZHF['extra']) => {
   if (ex) {
     for (const k in ex) {
       const l = ex[k].length;
-      if (l > 65535) err(9);
+      if (l > f4) err(9);
       le += l + 4;
     }
   }
@@ -2733,50 +2747,103 @@ const exfl = (ex?: ZHF['extra']) => {
 }
 
 // write zip header
-const wzh = (d: Uint8Array, b: number, f: ZHF, fn: Uint8Array, u: boolean, c: number, ce?: number, co?: Uint8Array) => {
-  const fl = fn.length, ex = f.extra, col = co && co.length;
-  let exl = exfl(ex);
-  wbytes(d, b, ce != null ? 0x2014B50 : 0x4034B50), b += 4;
-  if (ce != null) d[b++] = 20, d[b++] = f.os;
-  d[b] = 20, b += 2; // spec compliance? what's that?
-  d[b++] = (f.flag << 1) | (c < 0 && 8), d[b++] = u && 8;
-  d[b++] = f.compression & 255, d[b++] = f.compression >> 8;
-  const dt = new Date(f.mtime == null ? Date.now() : f.mtime), y = dt.getFullYear() - 1980;
-  if (y < 0 || y > 119) err(10);
-  wbytes(d, b, (y << 25) | ((dt.getMonth() + 1) << 21) | (dt.getDate() << 16) | (dt.getHours() << 11) | (dt.getMinutes() << 5) | (dt.getSeconds() >> 1)), b += 4;
-  if (c != -1) {
-    wbytes(d, b, f.crc);
-    wbytes(d, b + 4, c < 0 ? -c - 2 : c);
-    wbytes(d, b + 8, f.size);
+const wzh = (
+  f: ZHF,
+  fn: Uint8Array, // file name
+  u: boolean, // unicode
+  c: number, // compressed size
+  ce?: number, // (central dir only) local header offset
+  co?: Uint8Array // (central dir only) comment
+) => {
+  const fnl = fn.length, col = co ? co.length : 0,
+    cdh = ce != null, // central dir header
+    s = c < 0; // streaming mode
+  let ex = f.extra,
+    sc = s ? -c - 2 : c,
+    su = f.size,
+    _sc = sc > f8,
+    _ce = ce > f8 && f8;
+  // Zip64 extra field
+  if (_sc || su > f8 || _ce) {
+    const efl = _ce ? 24 : (_sc || !cdh) ? 16 : 8, ef = new u8(efl);
+    wbytes64(ef, 0, su);
+    wbytes64(ef, 8, sc);
+    wbytes64(ef, 16, ce);
+    ex = mrg({ 1: ef }, ex), su = f8, sc = efl > 8 ? f8 : sc;
+  } else if (!cdh && f.zip64) {
+    ex = mrg({ 1: [] }, ex); // marks Data Descriptor format as Zip64
   }
-  wbytes(d, b + 12, fl);
-  wbytes(d, b + 14, exl), b += 16;
-  if (ce != null) {
-    wbytes(d, b, col);
-    wbytes(d, b + 6, f.attrs);
-    wbytes(d, b + 10, ce), b += 14;
-  }
-  d.set(fn, b);
-  b += fl;
-  if (exl) {
-    for (const k in ex) {
-      const exf = ex[k], l = exf.length;
-      wbytes(d, b, +k);
-      wbytes(d, b + 2, l);
-      d.set(exf, b + 4), b += 4 + l;
+  function w(d: Uint8Array, b: number) {
+    wbytes(d, b, cdh ? 0x2014B50 : 0x4034B50), b += 4;
+    if (cdh) d[b++] = 20, d[b++] = f.os;
+    d[b] = 20, b += 2; // spec compliance? what's that?
+    d[b++] = (f.flag << 1) | (s && 8), d[b++] = u && 8;
+    d[b++] = f.compression & 255, d[b++] = f.compression >> 8;
+    const dt = new Date(f.mtime == null ? Date.now() : f.mtime), y = dt.getFullYear() - 1980;
+    if (y < 0 || y > 119) err(10);
+    wbytes(d, b, (y << 25) | ((dt.getMonth() + 1) << 21) | (dt.getDate() << 16) | (dt.getHours() << 11) | (dt.getMinutes() << 5) | (dt.getSeconds() >> 1)), b += 4;
+    if (!s || cdh) {
+      wbytes(d, b, f.crc);
+      wbytes(d, b + 4, sc);
+      wbytes(d, b + 8, su);
     }
+    wbytes(d, b + 12, fnl);
+    wbytes(d, b + 14, w.exl), b += 16;
+    if (cdh) {
+      wbytes(d, b, col);
+      wbytes(d, b + 6, f.attrs);
+      wbytes(d, b + 10, _ce || ce), b += 14;
+    }
+    d.set(fn, b), b += fnl;
+    if (w.exl) {
+      for (const k in ex) {
+        const exf = ex[k], l = exf.length;
+        wbytes(d, b, +k);
+        wbytes(d, b + 2, l);
+        d.set(exf, b += 4), b += l;
+      }
+    }
+    if (cdh && col) d.set(co, b);
   }
-  if (col) d.set(co, b), b += col;
-  return b;
+  w.exl = exfl(ex);
+  w.l = 30 + (cdh && 16) + fnl + w.exl + (cdh && col);
+  return w;
 }
 
-// write zip footer (end of central directory)
-const wzf = (o: Uint8Array, b: number, c: number, d: number, e: number) => {
-  wbytes(o, b, 0x6054B50); // skip disk
-  wbytes(o, b + 8, c);
-  wbytes(o, b + 10, c);
-  wbytes(o, b + 12, d);
-  wbytes(o, b + 16, e);
+// write zip footer
+const wzf = (
+  fl: number, // files length
+  cdl: number, // central directory length
+  cdo: number // central directory offset
+) => {
+  const _fl = fl > f4 && f4,
+    _cdl = cdl > f8 && f8,
+    _cdo = cdo > f8 && f8,
+    z64 = _fl || _cdl || _cdo;
+  function w(d: Uint8Array, b: number) {
+    if (z64) {
+      // Zip64 end of central directory record
+      wbytes(d, b, 0x6064B50);
+      d[b + 4] = 44;
+      d[b + 12] = d[b + 14] = 45;
+      wbytes64(d, b + 24, fl);
+      wbytes64(d, b + 32, fl);
+      wbytes64(d, b + 40, cdl);
+      wbytes64(d, b + 48, cdo);
+      // Zip64 end of central directory locator
+      wbytes(d, b + 56, 0x7064B50);
+      wbytes64(d, b + 64, cdo + cdl);
+      d[(b += 76) - 4] = 1;
+    }
+    // End of central directory record
+    wbytes(d, b, 0x6054B50); // skip disk
+    wbytes(d, b + 8, _fl || fl);
+    wbytes(d, b + 10, _fl || fl);
+    wbytes(d, b + 12, _cdl || cdl);
+    wbytes(d, b + 16, _cdo || cdo);
+  }
+  w.l = z64 ? 98 : 22;
+  return w;
 }
 
 /**
@@ -2827,6 +2894,14 @@ export interface ZipInputFile extends ZipAttributes {
   flag?: number;
 
   /**
+   * Flag used to enforce the Zip64 format for Data Descriptor as described
+   * in PKZIP's APPNOTE.txt, section 4.3.9.2.
+   * Set this flag to `true` if you suspect your file will be larger than 4GB
+   * before or after compression.
+   */
+  zip64?: boolean;
+
+  /**
    * The handler to be called when data is added. After passing this stream to
    * the ZIP file object, this handler will always be defined. To call it:
    * 
@@ -2859,6 +2934,12 @@ type AsyncZipDat = ZHF & {
   m?: Uint8Array;
   // unicode
   u: boolean;
+  // local file header offset
+  o?: number;
+  // local file header
+  lh?: ReturnType<typeof wzh>;
+  // central directory header
+  ch?: ReturnType<typeof wzh>;
 };
 
 type ZipDat = AsyncZipDat & {
@@ -2879,6 +2960,7 @@ export class ZipPassThrough implements ZipInputFile {
   comment?: string;
   extra?: Record<number, Uint8Array>;
   mtime?: GzipOptions['mtime'];
+  zip64?: boolean;
   ondata: AsyncFlateStreamHandler;
   private c: CRCV;
 
@@ -2938,6 +3020,7 @@ export class ZipDeflate implements ZipInputFile {
   comment?: string;
   extra?: Record<number, Uint8Array>;
   mtime?: GzipOptions['mtime'];
+  zip64?: boolean;
   ondata: AsyncFlateStreamHandler;
   private d: Deflate;
 
@@ -2988,6 +3071,7 @@ export class AsyncZipDeflate implements ZipInputFile {
   comment?: string;
   extra?: Record<number, Uint8Array>;
   mtime?: GzipOptions['mtime'];
+  zip64?: boolean;
   ondata: AsyncFlateStreamHandler;
   private d: AsyncDeflate;
   terminate: AsyncTerminable;
@@ -3041,7 +3125,7 @@ type ZIFE = {
   r: () => void;
 };
 
-type ZipInternalFile = ZHF & ZIFE;
+type ZipInternalFile = ZHF & ZIFE & { ch?: ReturnType<typeof wzh> };
 
 // TODO: Better tree shaking
 
@@ -3074,10 +3158,10 @@ export class Zip {
       const f = strToU8(file.filename), fl = f.length;
       const com = file.comment, o = com && strToU8(com);
       const u = fl != file.filename.length || (o && (com.length != o.length));
-      const hl = fl + exfl(file.extra) + 30;
-      if (fl > 65535) this.ondata(err(11, 0, 1), null, false);
-      const header = new u8(hl);
-      wzh(header, 0, file, f, u, -1);
+      if (fl > f4) this.ondata(err(11, 0, 1), null, false);
+      const lh = wzh(file, f, u, -1);
+      const header = new u8(lh.l);
+      lh(header, 0);
       let chks: Uint8Array[] = [header];
       const pAll = () => {
         for (const chk of chks) this.ondata(null, chk, false);
@@ -3112,13 +3196,18 @@ export class Zip {
           cl += dat.length;
           chks.push(dat);
           if (final) {
-            const dd = new u8(16);
+            let z64 = file.zip64, ddl = z64 ? 24 : 16, dd = new u8(ddl);
             wbytes(dd, 0, 0x8074B50)
             wbytes(dd, 4, file.crc);
-            wbytes(dd, 8, cl);
-            wbytes(dd, 12, file.size);
+            if (z64) {
+              wbytes64(dd, 8, cl);
+              wbytes64(dd, 16, file.size);
+            } else {
+              wbytes(dd, 8, cl);
+              wbytes(dd, 12, file.size);
+            }
             chks.push(dd);
-            uf.c = cl, uf.b = hl + cl + 16, uf.crc = file.crc, uf.size = file.size;
+            uf.c = cl, uf.b = lh.l + cl + ddl, uf.crc = file.crc, uf.size = file.size;
             if (tr) uf.r();
             tr = 1;
           } else if (tr) pAll();
@@ -3151,14 +3240,19 @@ export class Zip {
   }
 
   private e() {
-    let bt = 0, l = 0, tl = 0;
-    for (const f of this.u) tl += 46 + f.f.length + exfl(f.extra) + (f.o ? f.o.length : 0);
-    const out = new u8(tl + 22);
+    let o = 0, cdl = 0;
     for (const f of this.u) {
-      wzh(out, bt, f, f.f, f.u, -f.c - 2, l, f.o);
-      bt += 46 + f.f.length + exfl(f.extra) + (f.o ? f.o.length : 0), l += f.b;
+      f.ch = wzh(f, f.f, f.u, -f.c - 2, o, f.o);
+      o += f.b, cdl += f.ch.l;
     }
-    wzf(out, bt, this.u.length, tl, l)
+    const eocd = wzf(this.u.length, cdl, o);
+    const out = new u8(cdl + eocd.l);
+    o = 0;
+    for (const f of this.u) {
+      f.ch(out, o);
+      o += f.ch.l;
+    }
+    eocd(out, o);
     this.ondata(null, out, true);
     this.d = 2;
   }
@@ -3199,7 +3293,7 @@ export function zip(data: AsyncZippable, opts: AsyncZipOptions | FlateCallback, 
   const r: FlatZippable<true> = {};
   fltn(data, '', r, opts as AsyncZipOptions);
   const k = Object.keys(r);
-  let lft = k.length, o = 0, tot = 0;
+  let lft = k.length;
   const slft = lft, files = new Array<AsyncZipDat>(lft);
   const term: AsyncTerminable[] = [];
   const tAll = () => {
@@ -3210,22 +3304,24 @@ export function zip(data: AsyncZippable, opts: AsyncZipOptions | FlateCallback, 
   }
   mt(() => { cbd = cb; });
   const cbf = () => {
-    const out = new u8(tot + 22), oe = o, cdl = tot - o;
-    tot = 0;
+    let o = 0, cdl = 0;
+    for (let i = 0; i < slft; i++) {
+      const f = files[i], l = f.c.length;
+      f.o = o;
+      f.lh = wzh(f, f.f, f.u, l);
+      f.ch = wzh(f, f.f, f.u, l, o, f.m);
+      o += f.lh.l + l, cdl += f.ch.l;
+    }
+    const eocd = wzf(slft, cdl, o);
+    const out = new u8(o + cdl + eocd.l);
     for (let i = 0; i < slft; ++i) {
       const f = files[i];
-      try {
-        const l = f.c.length;
-        wzh(out, tot, f, f.f, f.u, l);
-        const badd = 30 + f.f.length + exfl(f.extra);
-        const loc = tot + badd;
-        out.set(f.c, loc);
-        wzh(out, o, f, f.f, f.u, l, tot, f.m), o += 16 + badd + (f.m ? f.m.length : 0), tot = loc + l;
-      } catch(e) {
-        return cbd(e, null);
-      }
+      f.lh(out, f.o);
+      out.set(f.c, f.o + f.lh.l);
+      f.ch(out, o);
+      o += f.ch.l;
     }
-    wzf(out, o, files.length, cdl, oe);
+    eocd(out, o);
     cbd(null, out);
   }
   if (!lft) cbf();
@@ -3237,14 +3333,12 @@ export function zip(data: AsyncZippable, opts: AsyncZipOptions | FlateCallback, 
     c.p(file);
     const f = strToU8(fn), s = f.length;
     const com = p.comment, m = com && strToU8(com), ms = m && m.length;
-    const exl = exfl(p.extra);
     const compression = p.level == 0 ? 0 : 8;
     const cbl: FlateCallback = (e, d) => {
       if (e) {
         tAll();
         cbd(e, null);
       } else {
-        const l = d.length;
         files[i] = mrg(p, {
           size,
           crc: c.d(),
@@ -3254,12 +3348,10 @@ export function zip(data: AsyncZippable, opts: AsyncZipOptions | FlateCallback, 
           u: s != fn.length || (m && (com.length != ms)),
           compression
         });
-        o += 30 + s + exl + l;
-        tot += 76 + 2 * (s + exl) + (ms || 0) + l;
         if (!--lft) cbf();
       }
     }
-    if (s > 65535) cbl(err(11, 0, 1), null);
+    if (s > f4) cbl(err(11, 0, 1), null);
     if (!compression) cbl(null, file);
     else if (size < 160000) {
       try {
@@ -3284,40 +3376,41 @@ export function zipSync(data: Zippable, opts?: ZipOptions) {
   const r: FlatZippable<false> = {};
   const files: ZipDat[] = [];
   fltn(data, '', r, opts);
-  let o = 0;
-  let tot = 0;
+  let o = 0, cdl = 0, zd: ZipDat;
   for (const fn in r) {
     const [file, p] = r[fn];
     const compression = p.level == 0 ? 0 : 8;
     const f = strToU8(fn), s = f.length;
     const com = p.comment, m = com && strToU8(com), ms = m && m.length;
-    const exl = exfl(p.extra);
-    if (s > 65535) err(11);
+    const u = s != fn.length || (m && (com.length != ms));
+    if (s > f4) err(11);
     const d = compression ? deflateSync(file, p) : file, l = d.length;
     const c = crc();
     c.p(file);
-    files.push(mrg(p, {
+    files.push(zd = mrg(p, {
       size: file.length,
       crc: c.d(),
       c: d,
       f,
       m,
-      u: s != fn.length || (m && (com.length != ms)),
+      u,
       o,
       compression
     }));
-    o += 30 + s + exl + l;
-    tot += 76 + 2 * (s + exl) + (ms || 0) + l;
+    zd.lh = wzh(zd, f, u, l);
+    zd.ch = wzh(zd, f, u, l, o, m);
+    o += zd.lh.l + l, cdl += zd.ch.l;
   }
-  const out = new u8(tot + 22), oe = o, cdl = tot - o;
+  const eocd = wzf(files.length, cdl, o);
+  const out = new u8(o + cdl + eocd.l);
   for (let i = 0; i < files.length; ++i) {
     const f = files[i];
-    wzh(out, f.o, f, f.f, f.u, f.c.length);
-    const badd = 30 + f.f.length + exfl(f.extra);
-    out.set(f.c, f.o + badd);
-    wzh(out, o, f, f.f, f.u, f.c.length, f.o, f.m), o += 16 + badd + (f.m ? f.m.length : 0);
+    f.lh(out, f.o);
+    out.set(f.c, f.o + f.lh.l);
+    f.ch(out, o);
+    o += f.ch.l;
   }
-  wzf(out, o, files.length, cdl, oe);
+  eocd(out, o);
   return out;
 }
 
@@ -3570,16 +3663,18 @@ export class Unzip {
           f = 1, is = i;
           this.d = null;
           this.c = 0;
-          const bf = b2(buf, i + 6), cmp = b2(buf, i + 8), u = bf & 2048, dd = bf & 8, fnl = b2(buf, i + 26), es = b2(buf, i + 28);
-          if (l > i + 30 + fnl + es) {
+          const bf = b2(buf, i + 6), cmp = b2(buf, i + 8), u = bf & 2048, dd = bf & 8, fnl = b2(buf, i + 26), exl = b2(buf, i + 28);
+          if (l > i + 30 + fnl + exl) {
             const chks: Uint8Array[] = [];
             this.k.unshift(chks);
             f = 2;
             let sc = b4(buf, i + 18), su = b4(buf, i + 22);
-            const fn = strFromU8(buf.subarray(i + 30, i += 30 + fnl), !u);
-            if (sc == 4294967295) { [sc, su] = dd ? [-2] : z64e(buf, i); }
-            else if (dd) sc = -1;
-            i += es;
+            const fn = strFromU8(buf.subarray(i += 30, i += fnl), !u);
+            if (su == f8) {
+              const ef = z64e(buf, i, exl);
+              if (ef) su = ef(su, 4), sc = ef(sc, 12);
+            } else if (dd) sc = sc == f8 ? -2 : -1;
+            i += exl;
             this.c = sc;
             let d: UnzipDecoder;
             const file = {
@@ -3682,23 +3777,21 @@ export function unzip(data: Uint8Array, opts: AsyncUnzipOptions | UnzipCallback,
       cbd(err(13, 0, 1), null);
       return tAll;
     }
-  };
+  }
   let lft = b2(data, e + 8);
   if (lft) {
     let c = lft;
     let o = b4(data, e + 16);
-    let z = o == 4294967295 || c == 65535;
-    if (z) {
-      let ze = b4(data, e - 12);
-      z = b4(data, ze) == 0x6064B50;
-      if (z) {
-        c = lft = b4(data, ze + 32);
-        o = b4(data, ze + 48);
+    if (o == f8 || c == f4) {
+      let ze = b8(data, e - 12);
+      if (b4(data, ze) == 0x6064B50) {
+        c = lft = b8(data, ze + 32);
+        o = b8(data, ze + 48);
       }
     }
     const fltr = opts && (opts as AsyncUnzipOptions).filter;
     for (let i = 0; i < c; ++i) {
-      const [c, sc, su, fn, no, off] = zh(data, o, z), b = slzh(data, off);
+      const [c, sc, su, fn, no, off] = zh(data, o), b = slzh(data, off);
       o = no
       const cbl: FlateCallback = (e, d) => {
         if (e) {
@@ -3746,22 +3839,20 @@ export function unzipSync(data: Uint8Array, opts?: UnzipOptions) {
   let e = data.length - 22;
   for (; b4(data, e) != 0x6054B50; --e) {
     if (!e || data.length - e > 65558) err(13);
-  };
+  }
   let c = b2(data, e + 8);
   if (!c) return {};
   let o = b4(data, e + 16);
-  let z = o == 4294967295 || c == 65535;
-  if (z) {
-    let ze = b4(data, e - 12);
-    z = b4(data, ze) == 0x6064B50;
-    if (z) {
-      c = b4(data, ze + 32);
-      o = b4(data, ze + 48);
+  if (o == f8 || c == f4) {
+    let ze = b8(data, e - 12);
+    if (b4(data, ze) == 0x6064B50) {
+      c = b8(data, ze + 32);
+      o = b8(data, ze + 48);
     }
   }
   const fltr = opts && opts.filter;
   for (let i = 0; i < c; ++i) {
-    const [c, sc, su, fn, no, off] = zh(data, o, z), b = slzh(data, off);
+    const [c, sc, su, fn, no, off] = zh(data, o), b = slzh(data, off);
     o = no;
     if (!fltr || fltr({
       name: fn,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2712,110 +2712,164 @@ const slzh = (d: Uint8Array, b: number) => b + 30 + b2(d, b + 26) + b2(d, b + 28
 
 // read zip header
 const zh = (d: Uint8Array, b: number) => {
-  const fnl = b2(d, b + 28), fn = strFromU8(d.subarray(b + 46, b + 46 + fnl), !(b2(d, b + 8) & 2048)), es = b + 46 + fnl, exl = b2(d, b + 30);
-  let su = b4(d, b + 24), sc: number | undefined, lo: number | undefined;
+  const u = b2(d, b + 8) & 2048,
+    cm = b2(d, b + 10),
+    sc = b4(d, b + 20),
+    su = b4(d, b + 24),
+    fnl = b2(d, b + 28),
+    exl = b2(d, b + 30),
+    fcl = b2(d, b + 32),
+    lo = b4(d, b + 42),
+    fn = strFromU8(d.subarray(b += 46, b += fnl), !u);
   if (su == f8) {
-    const ef = z64e(d, es, exl);
-    if (ef) su = ef(su, 4), sc = ef(sc, 12), lo = ef(lo, 20);
+    const ef = z64e(d, b, exl);
+    if (ef) return [cm, ef(sc, 12), ef(su, 4), fn, b + exl + fcl, ef(lo, 20)] as const;
   }
-  return [b2(d, b + 10), sc ?? b4(d, b + 20), su, fn, es + exl + b2(d, b + 32), lo ?? b4(d, b + 42)] as const;
+  return [cm, sc, su, fn, b + exl + fcl, lo] as const;
 }
 
 // read zip64 extra field
 const z64e = (d: Uint8Array, b: number, exl: number) => {
   let e = b + exl, id: number, l: number;
-  for (; b < e; b += l + 4) {
+  for (; b < e; b += 4 + l) {
     id = b2(d, b), l = b2(d, b + 2);
     if (id == 1) return <T>(v: T, o: 4 | 12 | 20) => l > o ? b8(d, b + o) : v;
   }
 }
 
-// zip header file
-type ZHF = Omit<ZipInputFile, 'terminate' | 'ondata' | 'filename'>;
+interface ZipFileEntry {
+  // file name
+  fn: Uint8Array;
+  // file comment
+  fc?: Uint8Array;
+  // general purpose bit flag (bits 0 to 7)
+  g1?: number;
+  // general purpose bit flag (bits 8 to 15)
+  g2?: number;
+  // modification datetime
+  md: number;
+  // compression method
+  cm: number;
+  // crc32
+  cr: number;
+  // size uncompressed (original size)
+  su: number;
+  // size compressed
+  sc: number;
+  os?: ZipAttributes['os'];
+  fa?: ZipAttributes['attrs'];
+  ex?: ZipAttributes['extra'];
+}
 
-// extra field length
-const exfl = (ex?: ZHF['extra']) => {
-  let le = 0;
+interface BufferedZipFileEntry extends ZipFileEntry {
+  // data compressed
+  dc: Uint8Array;
+  // local file header
+  lh: ReturnType<typeof wzh>;
+  // central directory header
+  ch: ReturnType<typeof wzh>;
+  // local header offset
+  o: number;
+}
+
+interface StreamedZipFileEntry extends ZipFileEntry {
+  // terminator
+  t: () => void;
+  // turn
+  r: () => void;
+  // central directory header
+  ch: ReturnType<typeof wzh>;
+  // local header size + compressed data size + data descriptor size
+  b: number;
+  // central directory header offset relative to the start of central directory
+  c: number;
+}
+
+// create zip file entry
+const zfe = <T extends ZipFileEntry>(fns: string, o: ZipAttributes) => {
+  const fn = strToU8(fns), fnl = fn.length,
+    fcs = o.comment, fc = fcs && strToU8(fcs),
+    u = fnl != fns.length || (fc && fc.length != fcs.length),
+    mt = o.mtime, dt = mt == null ? new Date() : new Date(mt), y = dt.getFullYear() - 1980,
+    ex = o.extra;
   if (ex) {
     for (const k in ex) {
-      const l = ex[k].length;
-      if (l > f4) err(9);
-      le += l + 4;
+      if (ex[k].length > f4) err(9);
     }
   }
-  return le;
+  if (y < 0 || y > 119) err(10);
+  if (fnl > f4) err(11);
+  return {
+    fn,
+    fc,
+    g2: u && 8,
+    md: y << 25
+      | dt.getMonth() + 1 << 21
+      | dt.getDate() << 16
+      | dt.getHours() << 11
+      | dt.getMinutes() << 5
+      | dt.getSeconds() >> 1,
+    os: o.os,
+    fa: o.attrs,
+    ex,
+  } as T;
 }
 
 // write zip header
-const wzh = (
-  f: ZHF,
-  fn: Uint8Array, // file name
-  u: boolean, // unicode
-  c: number, // compressed size
-  ce?: number, // (central dir only) local header offset
-  co?: Uint8Array // (central dir only) comment
-) => {
-  const fnl = fn.length, col = co ? co.length : 0,
-    cdh = ce != null, // central dir header
-    s = c < 0; // streaming mode
-  let ex = f.extra,
-    sc = s ? -c - 2 : c,
-    su = f.size,
-    _sc = sc > f8,
-    _ce = ce > f8 && f8;
-  // Zip64 extra field
-  if (_sc || su > f8 || _ce) {
-    const efl = _ce ? 24 : (_sc || !cdh) ? 16 : 8, ef = new u8(efl);
-    wbytes64(ef, 0, su);
-    wbytes64(ef, 8, sc);
-    wbytes64(ef, 16, ce);
-    ex = mrg({ 1: ef }, ex), su = f8, sc = efl > 8 ? f8 : sc;
-  } else if (!cdh && f.zip64) {
-    ex = mrg({ 1: [] }, ex); // marks Data Descriptor format as Zip64
+const wzh = (f: ZipFileEntry, lo?: number) => {
+  let cdh = lo != null,
+    { fn, fc, ex, sc, su } = f,
+    fnl = fn.length,
+    fcl = fc ? fc.length : 0,
+    exl = 0,
+    efl = (lo > f8) ? 24 : (su > f8) ? (sc > f8 || !cdh) ? 16 : 8 : 0; // Zip64 extra field length
+  if (efl) {
+    const ef = new u8(efl);
+    wbytes64(ef, 0, su), su = f8;
+    if (efl > 8) wbytes64(ef, 8, sc), sc = f8;
+    if (efl > 16) wbytes64(ef, 16, lo), lo = f8;
+    ex = mrg(ex, { 1: ef });
+  }
+  if (ex) {
+    for (const k in ex) exl += ex[k].length + 4;
   }
   function w(d: Uint8Array, b: number) {
     wbytes(d, b, cdh ? 0x2014B50 : 0x4034B50), b += 4;
     if (cdh) d[b++] = 20, d[b++] = f.os;
-    d[b] = 20, b += 2; // spec compliance? what's that?
-    d[b++] = (f.flag << 1) | (s && 8), d[b++] = u && 8;
-    d[b++] = f.compression & 255, d[b++] = f.compression >> 8;
-    const dt = new Date(f.mtime == null ? Date.now() : f.mtime), y = dt.getFullYear() - 1980;
-    if (y < 0 || y > 119) err(10);
-    wbytes(d, b, (y << 25) | ((dt.getMonth() + 1) << 21) | (dt.getDate() << 16) | (dt.getHours() << 11) | (dt.getMinutes() << 5) | (dt.getSeconds() >> 1)), b += 4;
-    if (!s || cdh) {
-      wbytes(d, b, f.crc);
-      wbytes(d, b + 4, sc);
-      wbytes(d, b + 8, su);
-    }
-    wbytes(d, b + 12, fnl);
-    wbytes(d, b + 14, w.exl), b += 16;
+    d[b] = 20; // spec compliance? what's that?
+    d[b + 2] = f.g1;
+    d[b + 3] = f.g2;
+    wbytes(d, b + 4, f.cm);
+    wbytes(d, b + 6, f.md);
+    wbytes(d, b + 10, f.cr);
+    wbytes(d, b + 14, sc);
+    wbytes(d, b + 18, su);
+    wbytes(d, b + 22, fnl);
+    wbytes(d, (b += 26) - 2, exl);
     if (cdh) {
-      wbytes(d, b, col);
-      wbytes(d, b + 6, f.attrs);
-      wbytes(d, b + 10, _ce || ce), b += 14;
+      wbytes(d, b, fcl);
+      wbytes(d, b + 6, f.fa);
+      wbytes(d, (b += 14) - 4, lo);
     }
     d.set(fn, b), b += fnl;
-    if (w.exl) {
+    if (exl) {
       for (const k in ex) {
-        const exf = ex[k], l = exf.length;
+        const ef = ex[k], l = ef.length;
         wbytes(d, b, +k);
         wbytes(d, b + 2, l);
-        d.set(exf, b += 4), b += l;
+        d.set(ef, b += 4), b += l;
       }
     }
-    if (cdh && col) d.set(co, b);
+    if (cdh && fcl) {
+      d.set(fc, b);
+    }
   }
-  w.exl = exfl(ex);
-  w.l = 30 + (cdh && 16) + fnl + w.exl + (cdh && col);
+  w.l = (cdh ? 46 + fcl : 30) + fnl + exl;
   return w;
 }
 
 // write zip footer
-const wzf = (
-  fl: number, // files length
-  cdl: number, // central directory length
-  cdo: number // central directory offset
-) => {
+const wzf = (fl: number, cdl: number, cdo: number) => {
   const _fl = fl > f4 && f4,
     _cdl = cdl > f8 && f8,
     _cdo = cdo > f8 && f8,
@@ -2923,28 +2977,6 @@ export interface ZipInputFile extends ZipAttributes {
    * processed if you have clean-up logic.
    */
   terminate?: AsyncTerminable;
-}
-
-type AsyncZipDat = ZHF & {
-  // compressed data
-  c: Uint8Array;
-  // filename
-  f: Uint8Array;
-  // comment
-  m?: Uint8Array;
-  // unicode
-  u: boolean;
-  // local file header offset
-  o?: number;
-  // local file header
-  lh?: ReturnType<typeof wzh>;
-  // central directory header
-  ch?: ReturnType<typeof wzh>;
-};
-
-type ZipDat = AsyncZipDat & {
-  // offset
-  o: number;
 }
 
 /**
@@ -3106,34 +3138,13 @@ export class AsyncZipDeflate implements ZipInputFile {
   }
 }
 
-type ZIFE = {
-  // compressed size
-  c: number;
-  // filename
-  f: Uint8Array;
-  // comment
-  o?: Uint8Array;
-  // unicode
-  u: boolean;
-  // byte offset
-  b: number;
-  // header offset
-  h: number;
-  // terminator
-  t: () => void;
-  // turn
-  r: () => void;
-};
-
-type ZipInternalFile = ZHF & ZIFE & { ch?: ReturnType<typeof wzh> };
-
 // TODO: Better tree shaking
 
 /**
  * A zippable archive to which files can incrementally be added
  */
 export class Zip {
-  private u: ZipInternalFile[];
+  private u: StreamedZipFileEntry[];
   private d: number;
 
   /**
@@ -3155,29 +3166,22 @@ export class Zip {
     // finishing or finished
     if (this.d & 2) this.ondata(err(4 + (this.d & 1) * 8, 0, 1), null, false);
     else {
-      const f = strToU8(file.filename), fl = f.length;
-      const com = file.comment, o = com && strToU8(com);
-      const u = fl != file.filename.length || (o && (com.length != o.length));
-      if (fl > f4) this.ondata(err(11, 0, 1), null, false);
-      const lh = wzh(file, f, u, -1);
-      const header = new u8(lh.l);
-      lh(header, 0);
-      let chks: Uint8Array[] = [header];
-      const pAll = () => {
-        for (const chk of chks) this.ondata(null, chk, false);
-        chks = [];
-      };
-      let tr = this.d;
-      this.d = 0;
-      const ind = this.u.length;
-      const uf = mrg(file, {
-        f,
-        u,
-        o,
-        t: () => { 
+      try {
+        let chks: Uint8Array[] = [];
+        const pAll = () => {
+          for (const chk of chks) this.ondata(null, chk, false);
+          chks = [];
+        };
+        let tr = this.d;
+        this.d = 0;
+        const ind = this.u.length;
+        const f = zfe<StreamedZipFileEntry>(file.filename, file);
+        f.cm = file.compression;
+        f.g1 = file.flag << 1;
+        f.t = () => {
           if (file.terminate) file.terminate();
-        },
-        r: () => {
+        };
+        f.r = () => {
           pAll();
           if (tr) {
             const nxt = this.u[ind + 1];
@@ -3185,35 +3189,57 @@ export class Zip {
             else this.d = 1;
           }
           tr = 1;
-        }
-      } as ZIFE);
-      let cl = 0;
-      file.ondata = (err, dat, final) => {
-        if (err) {
-          this.ondata(err, dat, final);
-          this.terminate();
-        } else {
-          cl += dat.length;
-          chks.push(dat);
-          if (final) {
-            let z64 = file.zip64, ddl = z64 ? 24 : 16, dd = new u8(ddl);
-            wbytes(dd, 0, 0x8074B50)
-            wbytes(dd, 4, file.crc);
-            if (z64) {
-              wbytes64(dd, 8, cl);
-              wbytes64(dd, 16, file.size);
-            } else {
-              wbytes(dd, 8, cl);
-              wbytes(dd, 12, file.size);
+        };
+        const ex = f.ex, z64 = file.zip64;
+        let lh: ReturnType<typeof wzh> | undefined, ddl: 0 | 16 | 24 | undefined, sc = 0;
+        file.ondata = (e, dc, final) => {
+          if (e) {
+            this.ondata(e, dc, final);
+            this.terminate();
+          } else {
+            sc += dc.length;
+            if (!lh) {
+              ddl = final ? 0 : z64 ? 24 : 16;
+              if (ddl) {
+                f.g1 |= 8;
+                if (z64) {
+                  // mark the Data Descriptor format as Zip64
+                  f.ex = mrg(ex, { 1: [] });
+                }
+              } else {
+                // first and final chunk - DD is not necessary
+                f.su = file.size, f.sc = sc, f.cr = file.crc;
+              }
+              lh = wzh(f), f.ex = ex;
+              const d = new u8(lh.l);
+              lh(d, 0);
+              chks.push(d);
             }
-            chks.push(dd);
-            uf.c = cl, uf.b = lh.l + cl + ddl, uf.crc = file.crc, uf.size = file.size;
-            if (tr) uf.r();
-            tr = 1;
-          } else if (tr) pAll();
-        }
+            chks.push(dc);
+            if (final) {
+              f.su = file.size, f.sc = sc, f.cr = file.crc, f.b = lh.l + sc + ddl;
+              if (ddl) {
+                const d = new u8(ddl);
+                wbytes(d, 0, 0x8074B50);
+                wbytes(d, 4, f.cr);
+                if (z64) {
+                  wbytes64(d, 8, sc);
+                  wbytes64(d, 16, f.su);
+                } else {
+                  wbytes(d, 8, sc);
+                  wbytes(d, 12, f.su);
+                }
+                chks.push(d);
+              }
+              if (tr) f.r();
+              tr = 1;
+            } else if (tr) pAll();
+          }
+        };
+        this.u.push(f);
+      } catch(e) {
+        this.ondata(e, null, false);
       }
-      this.u.push(uf);
     }
   }
 
@@ -3235,24 +3261,24 @@ export class Zip {
         this.e();
       },
       t: () => {}
-    } as unknown as ZipInternalFile);
+    } as unknown as StreamedZipFileEntry);
     this.d = 3;
   }
 
   private e() {
+    const files = this.u;
     let o = 0, cdl = 0;
-    for (const f of this.u) {
-      f.ch = wzh(f, f.f, f.u, -f.c - 2, o, f.o);
+    for (const f of files) {
+      f.ch = wzh(f, o);
+      f.c = cdl;
       o += f.b, cdl += f.ch.l;
     }
-    const eocd = wzf(this.u.length, cdl, o);
+    const eocd = wzf(files.length, cdl, o);
     const out = new u8(cdl + eocd.l);
-    o = 0;
-    for (const f of this.u) {
-      f.ch(out, o);
-      o += f.ch.l;
+    for (const f of files) {
+      f.ch(out, f.c);
     }
-    eocd(out, o);
+    eocd(out, cdl);
     this.ondata(null, out, true);
     this.d = 2;
   }
@@ -3292,9 +3318,9 @@ export function zip(data: AsyncZippable, opts: AsyncZipOptions | FlateCallback, 
   if (typeof cb != 'function') err(7);
   const r: FlatZippable<true> = {};
   fltn(data, '', r, opts as AsyncZipOptions);
-  const k = Object.keys(r);
-  let lft = k.length;
-  const slft = lft, files = new Array<AsyncZipDat>(lft);
+  const k = Object.keys(r), fl = k.length;
+  let lft = fl;
+  const files = Array<BufferedZipFileEntry>(fl);
   const term: AsyncTerminable[] = [];
   const tAll = () => {
     for (let i = 0; i < term.length; ++i) term[i]();
@@ -3305,61 +3331,55 @@ export function zip(data: AsyncZippable, opts: AsyncZipOptions | FlateCallback, 
   mt(() => { cbd = cb; });
   const cbf = () => {
     let o = 0, cdl = 0;
-    for (let i = 0; i < slft; i++) {
-      const f = files[i], l = f.c.length;
+    for (const f of files) {
+      f.lh = wzh(f);
+      f.ch = wzh(f, o);
       f.o = o;
-      f.lh = wzh(f, f.f, f.u, l);
-      f.ch = wzh(f, f.f, f.u, l, o, f.m);
-      o += f.lh.l + l, cdl += f.ch.l;
+      o += f.lh.l + f.sc, cdl += f.ch.l;
     }
-    const eocd = wzf(slft, cdl, o);
+    const eocd = wzf(fl, cdl, o);
     const out = new u8(o + cdl + eocd.l);
-    for (let i = 0; i < slft; ++i) {
-      const f = files[i];
+    for (const f of files) {
       f.lh(out, f.o);
-      out.set(f.c, f.o + f.lh.l);
+      out.set(f.dc, f.o + f.lh.l);
       f.ch(out, o);
       o += f.ch.l;
     }
     eocd(out, o);
     cbd(null, out);
   }
-  if (!lft) cbf();
-  // Cannot use lft because it can decrease
-  for (let i = 0; i < slft; ++i) {
-    const fn = k[i];
-    const [file, p] = r[fn];
-    const c = crc(), size = file.length;
-    c.p(file);
-    const f = strToU8(fn), s = f.length;
-    const com = p.comment, m = com && strToU8(com), ms = m && m.length;
-    const compression = p.level == 0 ? 0 : 8;
-    const cbl: FlateCallback = (e, d) => {
-      if (e) {
-        tAll();
-        cbd(e, null);
+  if (!fl) cbf();
+  try {
+    for (let i = 0; i < fl; ++i) {
+      const fns = k[i], [du, zo] = r[fns];
+      const c = crc();
+      const f = zfe<BufferedZipFileEntry>(fns, zo);
+      c.p(du);
+      f.cm = zo.level == 0 ? 0 : 8;
+      f.cr = c.d();
+      f.su = du.length;
+      const cbl: FlateCallback = (e, dc) => {
+        if (e) {
+          tAll();
+          cbd(e, null);
+        } else {
+          f.dc = dc;
+          f.sc = dc.length;
+          files[i] = f;
+          if (!--lft) cbf();
+        }
+      };
+      if (!f.cm) {
+        cbl(null, du);
+      } else if (f.su < 160000) {
+        cbl(null, deflateSync(du, zo));
       } else {
-        files[i] = mrg(p, {
-          size,
-          crc: c.d(),
-          c: d,
-          f,
-          m,
-          u: s != fn.length || (m && (com.length != ms)),
-          compression
-        });
-        if (!--lft) cbf();
+        term.push(deflate(du, zo, cbl));
       }
     }
-    if (s > f4) cbl(err(11, 0, 1), null);
-    if (!compression) cbl(null, file);
-    else if (size < 160000) {
-      try {
-        cbl(null, deflateSync(file, p));
-      } catch(e) {
-        cbl(e, null);
-      }
-    } else term.push(deflate(file, p, cbl));
+  } catch(e) {
+    tAll();
+    cbd(e, null);
   }
   return tAll;
 }
@@ -3374,39 +3394,30 @@ export function zip(data: AsyncZippable, opts: AsyncZipOptions | FlateCallback, 
 export function zipSync(data: Zippable, opts?: ZipOptions) {
   if (!opts) opts = {};
   const r: FlatZippable<false> = {};
-  const files: ZipDat[] = [];
+  const files: BufferedZipFileEntry[] = [];
   fltn(data, '', r, opts);
-  let o = 0, cdl = 0, zd: ZipDat;
-  for (const fn in r) {
-    const [file, p] = r[fn];
-    const compression = p.level == 0 ? 0 : 8;
-    const f = strToU8(fn), s = f.length;
-    const com = p.comment, m = com && strToU8(com), ms = m && m.length;
-    const u = s != fn.length || (m && (com.length != ms));
-    if (s > f4) err(11);
-    const d = compression ? deflateSync(file, p) : file, l = d.length;
+  let o = 0, cdl = 0;
+  for (const fns in r) {
+    const [du, zo] = r[fns];
     const c = crc();
-    c.p(file);
-    files.push(zd = mrg(p, {
-      size: file.length,
-      crc: c.d(),
-      c: d,
-      f,
-      m,
-      u,
-      o,
-      compression
-    }));
-    zd.lh = wzh(zd, f, u, l);
-    zd.ch = wzh(zd, f, u, l, o, m);
-    o += zd.lh.l + l, cdl += zd.ch.l;
+    const f = zfe<BufferedZipFileEntry>(fns, zo);
+    c.p(du);
+    f.cm = zo.level == 0 ? 0 : 8;
+    f.cr = c.d();
+    f.su = du.length;
+    f.dc = f.cm ? deflateSync(du, zo) : du;
+    f.sc = f.dc.length;
+    f.lh = wzh(f);
+    f.ch = wzh(f, o);
+    f.o = o;
+    files.push(f);
+    o += f.lh.l + f.sc, cdl += f.ch.l;
   }
   const eocd = wzf(files.length, cdl, o);
   const out = new u8(o + cdl + eocd.l);
-  for (let i = 0; i < files.length; ++i) {
-    const f = files[i];
+  for (const f of files) {
     f.lh(out, f.o);
-    out.set(f.c, f.o + f.lh.l);
+    out.set(f.dc, f.o + f.lh.l);
     f.ch(out, o);
     o += f.ch.l;
   }
@@ -3663,29 +3674,32 @@ export class Unzip {
           f = 1, is = i;
           this.d = null;
           this.c = 0;
-          const bf = b2(buf, i + 6), cmp = b2(buf, i + 8), u = bf & 2048, dd = bf & 8, fnl = b2(buf, i + 26), exl = b2(buf, i + 28);
+          const fnl = b2(buf, i + 26), exl = b2(buf, i + 28);
           if (l > i + 30 + fnl + exl) {
             const chks: Uint8Array[] = [];
             this.k.unshift(chks);
             f = 2;
+            const g = b2(buf, i + 6), dd = g & 8, u = g & 2048, cm = b2(buf, i + 8);
             let sc = b4(buf, i + 18), su = b4(buf, i + 22);
             const fn = strFromU8(buf.subarray(i += 30, i += fnl), !u);
-            if (su == f8) {
+            if (dd) {
+              sc = z64e(buf, i, exl) ? -2 : -1;
+            } else if (su == f8) {
               const ef = z64e(buf, i, exl);
               if (ef) su = ef(su, 4), sc = ef(sc, 12);
-            } else if (dd) sc = sc == f8 ? -2 : -1;
+            }
             i += exl;
             this.c = sc;
             let d: UnzipDecoder;
             const file = {
               name: fn,
-              compression: cmp,
+              compression: cm,
               start: () => {
                 if (!file.ondata) err(5);
                 if (!sc) file.ondata(null, et, true);
                 else {
-                  const ctr = this.o[cmp];
-                  if (!ctr) file.ondata(err(14, 'unknown compression type ' + cmp, 1), null, false);
+                  const ctr = this.o[cm];
+                  if (!ctr) file.ondata(err(14, 'unknown compression type ' + cm, 1), null, false);
                   d = sc < 0 ? new ctr(fn) : new ctr(fn, sc, su);
                   d.ondata = (err, dat, final) => { file.ondata(err, dat, final); }
                   for (const dat of chks) d.push(dat, false);
@@ -3766,7 +3780,6 @@ export function unzip(data: Uint8Array, opts: AsyncUnzipOptions | UnzipCallback,
   const tAll = () => {
     for (let i = 0; i < term.length; ++i) term[i]();
   }
-  const files: Unzipped = {};
   let cbd: UnzipCallback = (a, b) => {
     mt(() => { cb(a, b); });
   }
@@ -3789,16 +3802,17 @@ export function unzip(data: Uint8Array, opts: AsyncUnzipOptions | UnzipCallback,
         o = b8(data, ze + 48);
       }
     }
+    const files: Unzipped = {};
     const fltr = opts && (opts as AsyncUnzipOptions).filter;
     for (let i = 0; i < c; ++i) {
-      const [c, sc, su, fn, no, off] = zh(data, o), b = slzh(data, off);
+      const [cm, sc, su, fn, no, off] = zh(data, o), b = slzh(data, off);
       o = no
-      const cbl: FlateCallback = (e, d) => {
+      const cbl: FlateCallback = (e, du) => {
         if (e) {
           tAll();
           cbd(e, null);
         } else {
-          if (d) files[fn] = d;
+          if (du) files[fn] = du;
           if (!--lft) cbd(null, files);
         }
       }
@@ -3806,21 +3820,21 @@ export function unzip(data: Uint8Array, opts: AsyncUnzipOptions | UnzipCallback,
         name: fn,
         size: sc,
         originalSize: su,
-        compression: c
+        compression: cm
       })) {
-        if (!c) cbl(null, slc(data, b, b + sc))
-        else if (c == 8) {
-          const infl = data.subarray(b, b + sc);
+        if (!cm) cbl(null, slc(data, b, b + sc))
+        else if (cm == 8) {
+          const dc = data.subarray(b, b + sc);
           // Synchronously decompress under 512KB, or barely-compressed data
           if (su < 524288 || sc > 0.8 * su) {
             try {
-              cbl(null, inflateSync(infl, { out: new u8(su) }));
+              cbl(null, inflateSync(dc, { out: new u8(su) }));
             } catch(e) {
               cbl(e, null);
             }
           }
-          else term.push(inflate(infl, { size: su }, cbl));
-        } else cbl(err(14, 'unknown compression type ' + c, 1), null);
+          else term.push(inflate(dc, { size: su }, cbl));
+        } else cbl(err(14, 'unknown compression type ' + cm, 1), null);
       } else cbl(null, null);
     }
   } else cbd(null, {});
@@ -3852,17 +3866,17 @@ export function unzipSync(data: Uint8Array, opts?: UnzipOptions) {
   }
   const fltr = opts && opts.filter;
   for (let i = 0; i < c; ++i) {
-    const [c, sc, su, fn, no, off] = zh(data, o), b = slzh(data, off);
+    const [cm, sc, su, fn, no, off] = zh(data, o), b = slzh(data, off);
     o = no;
     if (!fltr || fltr({
       name: fn,
       size: sc,
       originalSize: su,
-      compression: c
+      compression: cm
     })) {
-      if (!c) files[fn] = slc(data, b, b + sc);
-      else if (c == 8) files[fn] = inflateSync(data.subarray(b, b + sc), { out: new u8(su) });
-      else err(14, 'unknown compression type ' + c);
+      if (!cm) files[fn] = slc(data, b, b + sc);
+      else if (cm == 8) files[fn] = inflateSync(data.subarray(b, b + sc), { out: new u8(su) });
+      else err(14, 'unknown compression type ' + cm);
     }
   }
   return files;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1188,7 +1188,7 @@ const b8 = (d: Uint8Array, b: number) => b4(d, b) + (b4(d, b + 4) * 4294967296);
 
 // write bytes, works only for values <= uint32
 const wbytes = (d: Uint8Array, b: number, v: number) => {
-  for (; v; ++b) d[b] = v, v >>>= 8;
+  for (; v; v >>>= 8) d[b++] = v;
 }
 
 const wbytes64 = (d: Uint8Array, b: number, v: number) => {
@@ -2712,7 +2712,7 @@ const slzh = (d: Uint8Array, b: number) => b + 30 + b2(d, b + 26) + b2(d, b + 28
 
 // read zip header
 const zh = (d: Uint8Array, b: number) => {
-  const u = b2(d, b + 8) & 2048,
+  let u = b2(d, b + 8) & 2048,
     cm = b2(d, b + 10),
     sc = b4(d, b + 20),
     su = b4(d, b + 24),
@@ -2720,21 +2720,37 @@ const zh = (d: Uint8Array, b: number) => {
     exl = b2(d, b + 30),
     fcl = b2(d, b + 32),
     lo = b4(d, b + 42),
-    fn = strFromU8(d.subarray(b += 46, b += fnl), !u);
-  if (su == f8) {
-    const ef = z64e(d, b, exl);
-    if (ef) return [cm, ef(sc, 12), ef(su, 4), fn, b + exl + fcl, ef(lo, 20)] as const;
-  }
+    fn = strFromU8(d.subarray(b += 46, b += fnl), !u),
+    ef = su == f8 && z64e(d, b, exl);
+  if (ef) su = ef(su, 4), sc = ef(sc, 12), lo = ef(lo, 20);
   return [cm, sc, su, fn, b + exl + fcl, lo] as const;
 }
 
 // read zip64 extra field
 const z64e = (d: Uint8Array, b: number, exl: number) => {
-  let e = b + exl, id: number, l: number;
+  let e = b + exl, l: number;
   for (; b < e; b += 4 + l) {
-    id = b2(d, b), l = b2(d, b + 2);
-    if (id == 1) return <T>(v: T, o: 4 | 12 | 20) => l > o ? b8(d, b + o) : v;
+    l = b2(d, b + 2);
+    if (b2(d, b) == 1) return <T>(v: T, o: 4 | 12 | 20) => l > o ? b8(d, b + o) : v;
   }
+}
+
+// read zip footer
+const zf = (d: Uint8Array) => {
+  let e = d.length - 22, fl: number, cdo: number;
+  for (; b4(d, e) != 0x6054B50; --e) {
+    if (!e || d.length - e > 65558) err(13);
+  }
+  fl = b2(d, e + 8);
+  cdo = b4(d, e + 16);
+  if (fl == f4 || cdo == f8) {
+    e = b8(d, e - 12);
+    if (b4(d, e) == 0x6064B50) {
+      fl = b8(d, e + 32);
+      cdo = b8(d, e + 48);
+    }
+  }
+  return [fl, cdo] as const;
 }
 
 interface ZipFileEntry {
@@ -3198,6 +3214,9 @@ export class Zip {
             this.terminate();
           } else {
             sc += dc.length;
+            if (final) {
+              f.su = file.size, f.sc = sc, f.cr = file.crc;
+            }
             if (!lh) {
               ddl = final ? 0 : z64 ? 24 : 16;
               if (ddl) {
@@ -3206,9 +3225,6 @@ export class Zip {
                   // mark the Data Descriptor format as Zip64
                   f.ex = mrg(ex, { 1: [] });
                 }
-              } else {
-                // first and final chunk - DD is not necessary
-                f.su = file.size, f.sc = sc, f.cr = file.crc;
               }
               lh = wzh(f), f.ex = ex;
               const d = new u8(lh.l);
@@ -3217,7 +3233,7 @@ export class Zip {
             }
             chks.push(dc);
             if (final) {
-              f.su = file.size, f.sc = sc, f.cr = file.crc, f.b = lh.l + sc + ddl;
+              f.b = lh.l + sc + ddl;
               if (ddl) {
                 const d = new u8(ddl);
                 wbytes(d, 0, 0x8074B50);
@@ -3266,16 +3282,18 @@ export class Zip {
   }
 
   private e() {
-    const files = this.u;
+    const files = this.u, fl = files.length;
     let o = 0, cdl = 0;
-    for (const f of files) {
+    for (let i = 0; i < fl; ++i) {
+      const f = files[i];
       f.ch = wzh(f, o);
       f.c = cdl;
       o += f.b, cdl += f.ch.l;
     }
-    const eocd = wzf(files.length, cdl, o);
+    const eocd = wzf(fl, cdl, o);
     const out = new u8(cdl + eocd.l);
-    for (const f of files) {
+    for (let i = 0; i < fl; ++i) {
+      const f = files[i];
       f.ch(out, f.c);
     }
     eocd(out, cdl);
@@ -3331,7 +3349,8 @@ export function zip(data: AsyncZippable, opts: AsyncZipOptions | FlateCallback, 
   mt(() => { cbd = cb; });
   const cbf = () => {
     let o = 0, cdl = 0;
-    for (const f of files) {
+    for (let i = 0; i < fl; ++i) {
+      const f = files[i];
       f.lh = wzh(f);
       f.ch = wzh(f, o);
       f.o = o;
@@ -3339,7 +3358,8 @@ export function zip(data: AsyncZippable, opts: AsyncZipOptions | FlateCallback, 
     }
     const eocd = wzf(fl, cdl, o);
     const out = new u8(o + cdl + eocd.l);
-    for (const f of files) {
+    for (let i = 0; i < fl; ++i) {
+      const f = files[i];
       f.lh(out, f.o);
       out.set(f.dc, f.o + f.lh.l);
       f.ch(out, o);
@@ -3396,7 +3416,7 @@ export function zipSync(data: Zippable, opts?: ZipOptions) {
   const r: FlatZippable<false> = {};
   const files: BufferedZipFileEntry[] = [];
   fltn(data, '', r, opts);
-  let o = 0, cdl = 0;
+  let o = 0, cdl = 0, fl: number;
   for (const fns in r) {
     const [du, zo] = r[fns];
     const c = crc();
@@ -3413,9 +3433,10 @@ export function zipSync(data: Zippable, opts?: ZipOptions) {
     files.push(f);
     o += f.lh.l + f.sc, cdl += f.ch.l;
   }
-  const eocd = wzf(files.length, cdl, o);
+  const eocd = wzf(fl = files.length, cdl, o);
   const out = new u8(o + cdl + eocd.l);
-  for (const f of files) {
+  for (let i = 0; i < fl; ++i) {
+    const f = files[i];
     f.lh(out, f.o);
     out.set(f.dc, f.o + f.lh.l);
     f.ch(out, o);
@@ -3682,11 +3703,11 @@ export class Unzip {
             const g = b2(buf, i + 6), dd = g & 8, u = g & 2048, cm = b2(buf, i + 8);
             let sc = b4(buf, i + 18), su = b4(buf, i + 22);
             const fn = strFromU8(buf.subarray(i += 30, i += fnl), !u);
+            const ef = su == f8 && z64e(buf, i, exl);
             if (dd) {
               sc = z64e(buf, i, exl) ? -2 : -1;
-            } else if (su == f8) {
-              const ef = z64e(buf, i, exl);
-              if (ef) su = ef(su, 4), sc = ef(sc, 12);
+            } else if (ef) {
+              su = ef(su, 4), sc = ef(sc, 12);
             }
             i += exl;
             this.c = sc;
@@ -3784,27 +3805,11 @@ export function unzip(data: Uint8Array, opts: AsyncUnzipOptions | UnzipCallback,
     mt(() => { cb(a, b); });
   }
   mt(() => { cbd = cb; });
-  let e = data.length - 22;
-  for (; b4(data, e) != 0x6054B50; --e) {
-    if (!e || data.length - e > 65558) {
-      cbd(err(13, 0, 1), null);
-      return tAll;
-    }
-  }
-  let lft = b2(data, e + 8);
-  if (lft) {
-    let c = lft;
-    let o = b4(data, e + 16);
-    if (o == f8 || c == f4) {
-      let ze = b8(data, e - 12);
-      if (b4(data, ze) == 0x6064B50) {
-        c = lft = b8(data, ze + 32);
-        o = b8(data, ze + 48);
-      }
-    }
+  try {
     const files: Unzipped = {};
-    const fltr = opts && (opts as AsyncUnzipOptions).filter;
-    for (let i = 0; i < c; ++i) {
+    const fltr = (opts as AsyncUnzipOptions).filter;
+    let [fl, o] = zf(data), lft = fl;
+    for (let i = 0; i < fl; ++i) {
       const [cm, sc, su, fn, no, off] = zh(data, o), b = slzh(data, off);
       o = no
       const cbl: FlateCallback = (e, du) => {
@@ -3827,17 +3832,18 @@ export function unzip(data: Uint8Array, opts: AsyncUnzipOptions | UnzipCallback,
           const dc = data.subarray(b, b + sc);
           // Synchronously decompress under 512KB, or barely-compressed data
           if (su < 524288 || sc > 0.8 * su) {
-            try {
-              cbl(null, inflateSync(dc, { out: new u8(su) }));
-            } catch(e) {
-              cbl(e, null);
-            }
+            cbl(null, inflateSync(dc, { out: new u8(su) }));
+          } else {
+            term.push(inflate(dc, { size: su }, cbl));
           }
-          else term.push(inflate(dc, { size: su }, cbl));
-        } else cbl(err(14, 'unknown compression type ' + cm, 1), null);
+        } else err(14, 'unknown compression type ' + cm);
       } else cbl(null, null);
     }
-  } else cbd(null, {});
+    if (!fl) cbd(null, files);
+  } catch(e) {
+    tAll();
+    cbd(e, null);
+  }
   return tAll;
 }
 
@@ -3850,22 +3856,9 @@ export function unzip(data: Uint8Array, opts: AsyncUnzipOptions | UnzipCallback,
  */
 export function unzipSync(data: Uint8Array, opts?: UnzipOptions) {
   const files: Unzipped = {};
-  let e = data.length - 22;
-  for (; b4(data, e) != 0x6054B50; --e) {
-    if (!e || data.length - e > 65558) err(13);
-  }
-  let c = b2(data, e + 8);
-  if (!c) return {};
-  let o = b4(data, e + 16);
-  if (o == f8 || c == f4) {
-    let ze = b8(data, e - 12);
-    if (b4(data, ze) == 0x6064B50) {
-      c = b8(data, ze + 32);
-      o = b8(data, ze + 48);
-    }
-  }
   const fltr = opts && opts.filter;
-  for (let i = 0; i < c; ++i) {
+  let [fl, o] = zf(data);
+  for (let i = 0; i < fl; ++i) {
     const [cm, sc, su, fn, no, off] = zh(data, o), b = slzh(data, off);
     o = no;
     if (!fltr || fltr({

--- a/test/3-zip.ts
+++ b/test/3-zip.ts
@@ -32,7 +32,7 @@ zipSyncFn('should create valid zip file', async () => {
     'some.file': new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]),
   }, { mtime: new Date('2025-01-31T00:00:00'), level: 0 });
 
-  assert.equal(zipped, hexToBytes([
+  assertSnapshotOfBytes(zipped, [
     // local file header 1
     '504B0304', '1400', '0000', '0000', '0000', '3F5A', '87668EEB', '0B000000', '0B000000', '0900', '0000',
     '68656C6C6F2E747874', // file name
@@ -55,7 +55,7 @@ zipSyncFn('should create valid zip file', async () => {
 
     // end of central directory record
     '504B0506', '0000', '0000', '0200', '0200', '6E000000', '5D000000', '0000',
-  ]));
+  ]);
   await assertSuccessfulUnpack(zipped, UnzipPassThrough, {
     'hello.txt': strToU8('Hello there'),
     'some.file': new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]),
@@ -70,7 +70,7 @@ zipSyncFn('should add Zip64 EOCD data when standard EOCDR is not enough', () => 
 
   const data = zipSync(filesToZip, { level: 0 });
 
-  assert.equal(data.slice(-98), hexToBytes([
+  assertSnapshotOfBytes(data.slice(-98), [
     // Zip64 end of central directory record:
     '50 4B 06 06', // 0x06064b50
     '2C 00 00 00 00 00 00 00', // 44
@@ -96,7 +96,7 @@ zipSyncFn('should add Zip64 EOCD data when standard EOCDR is not enough', () => 
     'EA 4D 36 00', // central dir length
     'EA 36 25 00', // central dir position
     '00 00',
-  ]));
+  ]);
   assert.equal(data.slice(-58, -54), data.slice(-10, -6)); // central dir length
   assert.equal(data.slice(-50, -46), data.slice(-6, -2)); // central dir position
   assert.is(new DataView(data.slice(-34, -30).buffer).getUint32(0, true), data.length - 98); // Zip64 EOCDR position
@@ -137,7 +137,7 @@ zipFn('should create valid zip file', async () => {
     );
   });
 
-  assert.equal(zipped, hexToBytes([
+  assertSnapshotOfBytes(zipped, [
     // local file header 1
     '504B0304', '1400', '0000', '0000', '0000', '3F5A', '87668EEB', '0B000000', '0B000000', '0900', '0000',
     '68656C6C6F2E747874', // file name
@@ -160,7 +160,7 @@ zipFn('should create valid zip file', async () => {
 
     // end of central directory record
     '504B0506', '0000', '0000', '0200', '0200', '6E000000', '5D000000', '0000',
-  ]));
+  ]);
   await assertSuccessfulUnpack(zipped, UnzipPassThrough, {
     'hello.txt': strToU8('Hello there'),
     'some.file': new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]),
@@ -190,39 +190,42 @@ zipClass('should create valid zip file', async () => {
     const someFile = new ZipPassThrough('some.file');
     someFile.mtime = new Date('2025-01-31T00:00:00');
     zip.add(someFile);
-    someFile.push(new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]), true);
+    someFile.push(new Uint8Array([0xAA, 0xBB]));
+    someFile.push(new Uint8Array([0xCC, 0xDD]), true);
 
     zip.end();
   });
 
-  assert.equal(zipped, hexToBytes([
-    // local file header 1
-    '504B0304', '1400', '0800', '0000', '0000', '3F5A', '00000000', '00000000', '00000000', '0900', '0000',
+  assertSnapshotOfBytes(zipped, [
+    // local file header 1 <- this file was added in one go, [data descriptor 1] was NOT needed
+    '504B0304', '1400', /*->*/'0000', // <- bit 3 of the general purpose bit flag is NOT set
+    '0000', '0000', '3F5A', /*->*/'87668EEB', '0B000000', '0B000000', // crc-32, sc, su are defined
+    '0900', '0000',
     '68656C6C6F2E747874', // file name
     '48656C6C6F207468657265', // file data
-    // data descriptor 1
-    '504B0708', '87668EEB', '0B000000', '0B000000',
 
-    // local file header 2
-    '504B0304', '1400', '0800', '0000', '0000', '3F5A', '00000000', '00000000', '00000000', '0900', '0000',
+    // local file header 2 <- this file was added in 2 parts, [data descriptor 2] was needed
+    '504B0304', '1400', /*->*/'0800', // <- bit 3 of the general purpose bit flag is set
+    '0000', '0000', '3F5A', /*->*/'00000000', '00000000', '00000000', // <- crc-32, sc, su set to zeros
+    '0900', '0000',
     '736F6D652E66696C65', // file name
     'AABBCCDD', // file data
     // data descriptor 2
-    '504B0708', 'A701B455', '04000000', '04000000',
+    '504B0708', /*->*/'A701B455', '04000000', '04000000', // <- crc-32, sc, su are here
 
     // central directory header 1
-    '504B0102', '1400', '1400', '0800', '0000', '0000', '3F5A', '87668EEB', '0B000000', '0B000000',
+    '504B0102', '1400', '1400', '0000', '0000', '0000', '3F5A', '87668EEB', '0B000000', '0B000000',
     '0900', '0000', '0000', '0000', '0000', '00000000', '00000000',
     '68656C6C6F2E747874', // file name
 
     // central directory header 2
     '504B0102', '1400', '1400', '0800', '0000', '0000', '3F5A', 'A701B455', '04000000', '04000000',
-    '0900', '0000', '0000', '0000', '0000', '00000000', '42000000',
+    '0900', '0000', '0000', '0000', '0000', '00000000', '32000000',
     '736F6D652E66696C65', // file name
 
     // end of central directory record
-    '504B0506', '0000', '0000', '0200', '0200', '6E000000', '7D000000', '0000',
-  ]));
+    '504B0506', '0000', '0000', '0200', '0200', '6E000000', '6D000000', '0000',
+  ]);
   await assertSuccessfulUnpack(zipped, UnzipPassThrough, {
     'hello.txt': strToU8('Hello there'),
     'some.file': new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]),
@@ -240,59 +243,110 @@ zipClass('should add Zip64 Extra Field if one of the fields in file header is to
     };
 
     class BigFileMock extends ZipPassThrough {
-      zip64 = true;
+      originalSizeMock: number;
+      zip64?: boolean;
 
       protected process(chunk: Uint8Array, final: boolean) {
-        this.size = Math.floor(1024 * 1024 * 1024 * 8.3); // mock uncompressed size 8.3GB
+        this.size = this.originalSizeMock;
         this.ondata(null, chunk, final);
       }
     }
 
-    const bigFile = new BigFileMock('some-big-file');
-    bigFile.compression = 8;
-    bigFile.mtime = Date.parse('2025-01-31T04:00:00');
-    zip.add(bigFile);
-    bigFile.push(new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]), true);
+    const bf1 = new BigFileMock('big-1');
+    bf1.originalSizeMock = 1024 * 1024 * 1024 * 8.3; // 8.3GB
+    bf1.zip64 = true; // flag to work must be set before `zip.add(file)`
+    bf1.compression = 8;
+    bf1.os = 3;
+    bf1.attrs = 0o644 << 16;
+    bf1.mtime = Date.parse('2025-01-31T04:00:00');
+    zip.add(bf1);
+    bf1.push(new Uint8Array([0xAA, 0xBB, 0xCC]));
+    bf1.push(new Uint8Array([0xDD]), true); // added in chunks
 
-    const smallFile = new ZipPassThrough('small-file');
-    smallFile.mtime = Date.parse('2025-01-16T08:00:00');
-    zip.add(smallFile);
-    smallFile.push(new Uint8Array([0xCC, 0xBB, 0xAA]), true);
+    const bf2 = new BigFileMock('big-2');
+    bf2.originalSizeMock = 1024 * 1024 * 1024 * 5.2; // 5.2GB
+    bf2.compression = 8;
+    bf2.extra = { 0xABCD: new Uint8Array([0xBA, 0xBA]) };
+    bf2.mtime = Date.parse('2025-01-16T08:00:00');
+    zip.add(bf2);
+    bf2.push(new Uint8Array([0xEE, 0xEE, 0xEE]), true);  // added in one go
+
+    const bf3 = new BigFileMock('big-3');
+    bf3.originalSizeMock = 1024 * 1024 * 512; // 512MB
+    bf3.zip64 = true; // should be important only in [local file header 3]
+    bf3.compression = 8;
+    bf3.mtime = Date.parse('2025-01-16T12:00:00');
+    zip.add(bf3);
+    bf3.push(new Uint8Array([0x77, 0x77]));
+    bf3.push(new Uint8Array([0x77]), true);
+
+    const sf = new ZipPassThrough('small');
+    sf.zip64 = true; // should be ignored when it turns out Data Descriptor is not needed
+    sf.mtime = new Date('2025-01-01T16:00:00');
+    sf.comment = 'comment sample';
+    zip.add(sf);
+    sf.push(new Uint8Array([0xCC, 0xBB, 0xAA]), true);
 
     zip.end();
   });
 
-  assert.equal(zipped, hexToBytes([
+  assertSnapshotOfBytes(zipped, [
     // local file header 1
-    '504B0304', '1400', '0800', '0800', '0020', '3F5A', '00000000', '00000000', '00000000', '0D00', '0400',
-    '736F6D652D6269672D66696C65', // file name
-    '0100', '0000', // <- Zip64 extra field with zero fields - only to indicate that [data descriptor 1] is in Zip64 format
+    '504B0304', '1400', '0800', '0800', '0020', '3F5A', /*->*/'00000000', '00000000', '00000000'/*<-*/, '0500', '0400',
+    '6269672D31', // file name
+    '0100 0000', // <- Zip64 extra field with zero fields - only to indicate that [data descriptor 1] is in Zip64 format
     'AABBCCDD', // file data
     // data descriptor 1
     '504B0708', 'A701B455', '0400000000000000', '3333331302000000', // <- 8 bytes per size field!
 
     // local file header 2
-    '504B0304', '1400', '0800', '0000', '0040', '305A', '00000000', '00000000', '00000000', '0A00', '0000',
-    '736D616C6C2D66696C65', // file name
+    '504B0304', '1400', '0000', '0800', '0040', '305A', 'A53572DB', /*->*/'FFFFFFFF', 'FFFFFFFF'/*<-*/, '0500', '1A00',
+    '6269672D32', // file name
+    '0100 1000 CCCCCC4C01000000 0300000000000000', // <- Zip64 extra field with two fields
+    'CDAB 0200 BABA', // custom extra field
+    'EEEEEE', // file data
+
+    // local file header 3
+    '504B0304', '1400', '0800', '0800', '0060', '305A', /*->*/'00000000', '00000000', '00000000'/*<-*/, '0500', '0400',
+    '6269672D33', // file name
+    '0100 0000', // <- Zip64 extra field with zero fields, thanks to `zip64` flag
+    '777777', // file data
+    // data descriptor 3
+    '504B0708', '69ACE000', '0300000000000000', '0000002000000000',
+
+    // local file header 4
+    '504B0304', '1400', '0000', '0000', '0080', '215A', 'B38BC656', '03000000', '03000000', '0500', '0000',
+    '736D616C6C', // file name
     'CCBBAA', // file data
-    // data descriptor 2
-    '504B0708', 'B38BC656', '03000000', '03000000',
 
     // central directory header 1
-    '504B0102', '1400', '1400', '0800', '0800', '0020', '3F5A', 'A701B455', '04000000',
-    'FFFFFFFF', // <- standard field for uncompressed file size is set to 0xffffffff
-    '0D00', '0C00', '0000', '0000', '0000', '00000000', '00000000',
-    '736F6D652D6269672D66696C65', // file name
-    '0100', '0800', '3333331302000000', // <- Zip64 extra field with one field - uncompressed file size
+    '504B0102', '1403', '1400', '0800', '0800', '0020', '3F5A', 'A701B455', '04000000', /*->*/'FFFFFFFF'/*<-*/,
+    '0500', '0C00', '0000', '0000', '0000', '0000A401', '00000000',
+    '6269672D31', // file name
+    '0100 0800 3333331302000000', // <- Zip64 extra field with one field
 
     // central directory header 2
-    '504B0102', '1400', '1400', '0800', '0000', '0040', '305A', 'B38BC656', '03000000', '03000000',
-    '0A00', '0000', '0000', '0000', '0000', '00000000', '4B000000',
-    '736D616C6C2D66696C65', // file name
+    '504B0102', '1400', '1400', '0000', '0800', '0040', '305A', 'A53572DB', '03000000', /*->*/'FFFFFFFF'/*<-*/,
+    '0500', '1200', '0000', '0000', '0000', '00000000', '43000000',
+    '6269672D32',  // file name
+    '0100 0800 CCCCCC4C01000000', // <- Zip64 extra field with one field
+    'CDAB 0200 BABA', // custom extra field
+
+    // central directory header 3
+    '504B0102', '1400', '1400', '0800', '0800', '0060', '305A', '69ACE000', '03000000', '00000020',
+    '0500', '0000', '0000', '0000', '0000', '00000000', '83000000',
+    '6269672D33', // file name
+    // no need for Zip64 extra field
+
+    // central directory header 4
+    '504B0102', '1400', '1400', '0000', '0000', '0080', '215A', 'B38BC656', '03000000', '03000000',
+    '0500', '0000', '0E00', '0000', '0000', '00000000', 'C5000000',
+    '736D616C6C', // file name
+    '636F6D6D656E742073616D706C65', // file comment
 
     // end of central directory record
-    '504B0506', '0000', '0000', '0200', '0200', '7F000000', '86000000', '0000',
-  ]));
+    '504B0506', '0000', '0000', '0400', '0400', 'F8000000', 'EB000000', '0000',
+  ]);
 });
 
 zipClass.run();
@@ -331,8 +385,38 @@ unzipping('should unpack zip where some file has Zip64 Extra Field, but there is
   });
 });
 
+unzipping('should handle files with Data Descriptor in Zip64 format', async () => {
+  const zipped = hexToBytes([
+    '504B03041400080000000060215A000000000000000000000000020004006631',
+    '0100 0000', // Zip64 extra field with zero fields
+    '6C6F72656D20697073756D20646F6C6F7220736974',
+    '504B0708 38284BA5 1500000000000000 1500000000000000', // Data Descriptor 1 in Zip64 format
+    '504B03041400080000000070215A000000000000000000000000020000006632616D65742C20636F6E7365637465747572',
+    '504B0708 C82D7309 11000000 11000000', // Data Descriptor 2
+    '504B03041400000000000080215A000000000000000000000000020000006633',
+    '504B010214001400080000000060215A38284BA515000000150000000200000000000000000000000000000000006631',
+    '504B010214001400080000000070215AC82D730911000000110000000200000000000000000000000000510000006632',
+    '504B010214001400000000000080215A0000000000000000000000000200000005000000000000000000920000006633',
+    '68656C6C6F', // file 3 comment
+    '504B0506000000000300030095000000B20000000000',
+  ]);
+
+  await assertSuccessfulUnpack(zipped, UnzipPassThrough, {
+    'f1': strToU8('lorem ipsum dolor sit'),
+    'f2': strToU8('amet, consectetur'),
+    'f3': new Uint8Array(), // empty file
+  });
+});
+
 unzipping.run();
 
+
+function assertSnapshotOfBytes(actual: Uint8Array, expects: string | string[]) { // for better diff printing
+  assert.equal(
+    Array.from(actual, n => n.toString(16).toUpperCase().padStart(2, '0')).join(' '),
+    (Array.isArray(expects) ? expects.join('') : expects).replace(/\s/g, '').replace(/\S{2}(?!$)/g, '$& '),
+  );
+}
 
 function hexToBytes(hex: string | string[]) {
   const str = Array.isArray(hex) ? hex.join('') : hex;

--- a/test/3-zip.ts
+++ b/test/3-zip.ts
@@ -1,1 +1,387 @@
-// TODO: test ZIP
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+import {
+  strToU8,
+  unzip,
+  Unzip,
+  UnzipDecoderConstructor,
+  UnzipPassThrough,
+  Unzipped,
+  unzipSync,
+  zip,
+  Zip,
+  ZipPassThrough,
+  zipSync,
+} from '../src';
+
+/**
+ * TODO: test ZIP
+ *
+ * Notes:
+ * 1. zip archives store file times as local time, using UTC
+ *    times would cause tests below to fail in other timezones.
+ *    So `new Date('2025-01-31T00:00:00')` (local) will work
+ *    fine, while `new Date('2025-01-31')` (UTC) will not.
+ */
+
+const zipSyncFn = suite('zipSync');
+
+zipSyncFn('should create valid zip file', async () => {
+  const zipped = zipSync({
+    'hello.txt': strToU8('Hello there'),
+    'some.file': new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]),
+  }, { mtime: new Date('2025-01-31T00:00:00'), level: 0 });
+
+  assert.equal(zipped, hexToBytes([
+    // local file header 1
+    '504B0304', '1400', '0000', '0000', '0000', '3F5A', '87668EEB', '0B000000', '0B000000', '0900', '0000',
+    '68656C6C6F2E747874', // file name
+    '48656C6C6F207468657265', // file data
+
+    // local file header 2
+    '504B0304', '1400', '0000', '0000', '0000', '3F5A', 'A701B455', '04000000', '04000000', '0900', '0000',
+    '736F6D652E66696C65', // file name
+    'AABBCCDD', // file data
+
+    // central directory header 1
+    '504B0102', '1400', '1400', '0000', '0000', '0000', '3F5A', '87668EEB', '0B000000', '0B000000',
+    '0900', '0000', '0000', '0000', '0000', '00000000', '00000000',
+    '68656C6C6F2E747874', // file name
+
+    // central directory header 2
+    '504B0102', '1400', '1400', '0000', '0000', '0000', '3F5A', 'A701B455', '04000000', '04000000',
+    '0900', '0000', '0000', '0000', '0000', '00000000', '32000000',
+    '736F6D652E66696C65', // file name
+
+    // end of central directory record
+    '504B0506', '0000', '0000', '0200', '0200', '6E000000', '5D000000', '0000',
+  ]));
+  await assertSuccessfulUnpack(zipped, UnzipPassThrough, {
+    'hello.txt': strToU8('Hello there'),
+    'some.file': new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]),
+  });
+});
+
+zipSyncFn('should add Zip64 EOCD data when standard EOCDR is not enough', () => {
+  const filesToZip = {};
+  for (let i = 0; i < 70_000; i++) {
+    filesToZip[i] = new Uint8Array();
+  }
+
+  const data = zipSync(filesToZip, { level: 0 });
+
+  assert.equal(data.slice(-98), hexToBytes([
+    // Zip64 end of central directory record:
+    '50 4B 06 06', // 0x06064b50
+    '2C 00 00 00 00 00 00 00', // 44
+    '2D 00', // 45 | 0
+    '2D 00', // 45 | 0
+    '00 00 00 00',
+    '00 00 00 00',
+    '70 11 01 00 00 00 00 00', // 70_000
+    '70 11 01 00 00 00 00 00', // 70_000
+    'EA 4D 36 00 00 00 00 00', // central dir length
+    'EA 36 25 00 00 00 00 00', // central dir position
+    // Zip64 end of central directory locator:
+    '50 4B 06 07', // 0x07064b50
+    '00 00 00 00',
+    'D4 84 5B 00 00 00 00 00', // Zip64 EOCDR position
+    '01 00 00 00', // 1 - total number of disks
+    // End of central directory record:
+    '50 4B 05 06', // 0x06054b50
+    '00 00',
+    '00 00',
+    'FF FF', // files count set to max 0xffff - actual value in Zip64 EOCDR
+    'FF FF', // as above
+    'EA 4D 36 00', // central dir length
+    'EA 36 25 00', // central dir position
+    '00 00',
+  ]));
+  assert.equal(data.slice(-58, -54), data.slice(-10, -6)); // central dir length
+  assert.equal(data.slice(-50, -46), data.slice(-6, -2)); // central dir position
+  assert.is(new DataView(data.slice(-34, -30).buffer).getUint32(0, true), data.length - 98); // Zip64 EOCDR position
+});
+
+zipSyncFn('should not add Zip64 EOCD data when is it not necessary', () => {
+  const filesToZip = {};
+  for (let i = 0; i < 65_535; i++) {
+    filesToZip[i] = new Uint8Array();
+  }
+
+  const data = zipSync(filesToZip, { level: 0 });
+
+  const dv = new DataView(data.buffer);
+  for (let i = data.length - 4; i >= 0; i--) {
+    const signature = dv.getUint32(i, true);
+    if (signature === 0x06054B50) {
+      assert.is(i, data.length - 22);
+    }
+    assert.is.not(signature, 0x06064B50);
+    assert.is.not(signature, 0x07064B50);
+  }
+});
+
+zipSyncFn.run();
+
+
+const zipFn = suite('zip');
+
+zipFn('should create valid zip file', async () => {
+  const zipped = await new Promise<Uint8Array>((resolve, reject) => {
+    zip({
+        'hello.txt': strToU8('Hello there'),
+        'some.file': new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]),
+      },
+      { mtime: Date.parse('2025-01-31T00:00:00'), level: 0 },
+      (err, data) => err ? reject(err) : resolve(data),
+    );
+  });
+
+  assert.equal(zipped, hexToBytes([
+    // local file header 1
+    '504B0304', '1400', '0000', '0000', '0000', '3F5A', '87668EEB', '0B000000', '0B000000', '0900', '0000',
+    '68656C6C6F2E747874', // file name
+    '48656C6C6F207468657265', // file data
+
+    // local file header 2
+    '504B0304', '1400', '0000', '0000', '0000', '3F5A', 'A701B455', '04000000', '04000000', '0900', '0000',
+    '736F6D652E66696C65', // file name
+    'AABBCCDD', // file data
+
+    // central directory header 1
+    '504B0102', '1400', '1400', '0000', '0000', '0000', '3F5A', '87668EEB', '0B000000', '0B000000',
+    '0900', '0000', '0000', '0000', '0000', '00000000', '00000000',
+    '68656C6C6F2E747874', // file name
+
+    // central directory header 2
+    '504B0102', '1400', '1400', '0000', '0000', '0000', '3F5A', 'A701B455', '04000000', '04000000',
+    '0900', '0000', '0000', '0000', '0000', '00000000', '32000000',
+    '736F6D652E66696C65', // file name
+
+    // end of central directory record
+    '504B0506', '0000', '0000', '0200', '0200', '6E000000', '5D000000', '0000',
+  ]));
+  await assertSuccessfulUnpack(zipped, UnzipPassThrough, {
+    'hello.txt': strToU8('Hello there'),
+    'some.file': new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]),
+  });
+});
+
+zipFn.run();
+
+
+const zipClass = suite('Zip');
+
+zipClass('should create valid zip file', async () => {
+  const zipped = await new Promise<Uint8Array>((resolve, reject) => {
+    const chunks = [];
+    const zip = new Zip();
+    zip.ondata = (err, chunk, final) => {
+      if (err) reject(err);
+      chunks.push(chunk);
+      if (final) resolve(mergeChunks(chunks));
+    };
+
+    const txtFile = new ZipPassThrough('hello.txt');
+    txtFile.mtime = new Date('2025-01-31 00:00');
+    zip.add(txtFile);
+    txtFile.push(strToU8('Hello there'), true);
+
+    const someFile = new ZipPassThrough('some.file');
+    someFile.mtime = new Date('2025-01-31T00:00:00');
+    zip.add(someFile);
+    someFile.push(new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]), true);
+
+    zip.end();
+  });
+
+  assert.equal(zipped, hexToBytes([
+    // local file header 1
+    '504B0304', '1400', '0800', '0000', '0000', '3F5A', '00000000', '00000000', '00000000', '0900', '0000',
+    '68656C6C6F2E747874', // file name
+    '48656C6C6F207468657265', // file data
+    // data descriptor 1
+    '504B0708', '87668EEB', '0B000000', '0B000000',
+
+    // local file header 2
+    '504B0304', '1400', '0800', '0000', '0000', '3F5A', '00000000', '00000000', '00000000', '0900', '0000',
+    '736F6D652E66696C65', // file name
+    'AABBCCDD', // file data
+    // data descriptor 2
+    '504B0708', 'A701B455', '04000000', '04000000',
+
+    // central directory header 1
+    '504B0102', '1400', '1400', '0800', '0000', '0000', '3F5A', '87668EEB', '0B000000', '0B000000',
+    '0900', '0000', '0000', '0000', '0000', '00000000', '00000000',
+    '68656C6C6F2E747874', // file name
+
+    // central directory header 2
+    '504B0102', '1400', '1400', '0800', '0000', '0000', '3F5A', 'A701B455', '04000000', '04000000',
+    '0900', '0000', '0000', '0000', '0000', '00000000', '42000000',
+    '736F6D652E66696C65', // file name
+
+    // end of central directory record
+    '504B0506', '0000', '0000', '0200', '0200', '6E000000', '7D000000', '0000',
+  ]));
+  await assertSuccessfulUnpack(zipped, UnzipPassThrough, {
+    'hello.txt': strToU8('Hello there'),
+    'some.file': new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]),
+  });
+});
+
+zipClass('should add Zip64 Extra Field if one of the fields in file header is too small', async () => {
+  const zipped = await new Promise<Uint8Array>((resolve, reject) => {
+    const chunks = [];
+    const zip = new Zip();
+    zip.ondata = (err, chunk, final) => {
+      if (err) reject(err);
+      chunks.push(chunk);
+      if (final) resolve(mergeChunks(chunks));
+    };
+
+    class BigFileMock extends ZipPassThrough {
+      zip64 = true;
+
+      protected process(chunk: Uint8Array, final: boolean) {
+        this.size = Math.floor(1024 * 1024 * 1024 * 8.3); // mock uncompressed size 8.3GB
+        this.ondata(null, chunk, final);
+      }
+    }
+
+    const bigFile = new BigFileMock('some-big-file');
+    bigFile.compression = 8;
+    bigFile.mtime = Date.parse('2025-01-31T04:00:00');
+    zip.add(bigFile);
+    bigFile.push(new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]), true);
+
+    const smallFile = new ZipPassThrough('small-file');
+    smallFile.mtime = Date.parse('2025-01-16T08:00:00');
+    zip.add(smallFile);
+    smallFile.push(new Uint8Array([0xCC, 0xBB, 0xAA]), true);
+
+    zip.end();
+  });
+
+  assert.equal(zipped, hexToBytes([
+    // local file header 1
+    '504B0304', '1400', '0800', '0800', '0020', '3F5A', '00000000', '00000000', '00000000', '0D00', '0400',
+    '736F6D652D6269672D66696C65', // file name
+    '0100', '0000', // <- Zip64 extra field with zero fields - only to indicate that [data descriptor 1] is in Zip64 format
+    'AABBCCDD', // file data
+    // data descriptor 1
+    '504B0708', 'A701B455', '0400000000000000', '3333331302000000', // <- 8 bytes per size field!
+
+    // local file header 2
+    '504B0304', '1400', '0800', '0000', '0040', '305A', '00000000', '00000000', '00000000', '0A00', '0000',
+    '736D616C6C2D66696C65', // file name
+    'CCBBAA', // file data
+    // data descriptor 2
+    '504B0708', 'B38BC656', '03000000', '03000000',
+
+    // central directory header 1
+    '504B0102', '1400', '1400', '0800', '0800', '0020', '3F5A', 'A701B455', '04000000',
+    'FFFFFFFF', // <- standard field for uncompressed file size is set to 0xffffffff
+    '0D00', '0C00', '0000', '0000', '0000', '00000000', '00000000',
+    '736F6D652D6269672D66696C65', // file name
+    '0100', '0800', '3333331302000000', // <- Zip64 extra field with one field - uncompressed file size
+
+    // central directory header 2
+    '504B0102', '1400', '1400', '0800', '0000', '0040', '305A', 'B38BC656', '03000000', '03000000',
+    '0A00', '0000', '0000', '0000', '0000', '00000000', '4B000000',
+    '736D616C6C2D66696C65', // file name
+
+    // end of central directory record
+    '504B0506', '0000', '0000', '0200', '0200', '7F000000', '86000000', '0000',
+  ]));
+});
+
+zipClass.run();
+
+
+const unzipping = suite('unzipping');
+
+unzipping('should unpack zip where some file has Zip64 Extra Field, but there is no Zip64 EOCD', async () => {
+  const zipped = hexToBytes([
+    '504B030414000000000000083F5AA701B455FFFFFFFFFFFFFFFF080014006269672D66696C65',
+    '0100 1000 3333331302000000 0400000000000000', // Zip64 extra field with two fields
+    'AABBCCDD',
+    '504B030414000000000000083F5A42E2D40E01000000010000000A000000736D616C6C2D66696C652E',
+    '504B0102140014000000000000083F5AA701B45504000000FFFFFFFF08000C0000000000000000000000000000006269672D66696C65',
+    '0100 0800 3333331302000000', // Zip64 extra field with one field
+    '504B0102140014000000000000083F5A42E2D40E01000000010000000A000000000000000000000000003E000000736D616C6C2D66696C65',
+    '504B050600000000020002007A000000670000000000',
+  ]);
+
+  unzipSync(zipped, {
+    filter: (file) => {
+      if (file.name === 'big-file') {
+        assert.is(file.originalSize, 8912057139); // should get uncompressed size from Zip64 extra field
+      } else if (file.name === 'small-file') {
+        assert.is(file.originalSize, 1);
+      } else {
+        assert.unreachable();
+      }
+      return false;
+    },
+  });
+
+  await assertSuccessfulUnpack(zipped, UnzipPassThrough, {
+    'big-file': new Uint8Array([0xAA, 0xBB, 0xCC, 0xDD]),
+    'small-file': strToU8('.'),
+  });
+});
+
+unzipping.run();
+
+
+function hexToBytes(hex: string | string[]) {
+  const str = Array.isArray(hex) ? hex.join('') : hex;
+  const b = Buffer.from(str.replace(/\s/g, ''), 'hex');
+  return new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+}
+
+function mergeChunks(chunks: Buffer[]) {
+  const b = Buffer.concat(chunks);
+  return new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+}
+
+async function assertSuccessfulUnpack(zipArchive: Uint8Array, Decoder: UnzipDecoderConstructor, expected: Unzipped) {
+  assert.equal(unpackSync(zipArchive), expected);
+  assert.equal(await unpackAsync(zipArchive), expected);
+  assert.equal(await unpackStream(zipArchive, Decoder), expected);
+}
+
+function unpackSync(zipArchive: Uint8Array) {
+  return unzipSync(zipArchive);
+}
+
+function unpackAsync(zipArchive: Uint8Array) {
+  return new Promise((resolve, reject) => {
+    unzip(zipArchive, (err, data) => err ? reject(err) : resolve(data));
+  });
+}
+
+function unpackStream(zipArchive: Uint8Array, Decoder: UnzipDecoderConstructor) {
+  return new Promise(async (resolve) => {
+    const result = {};
+    const toAwait = [];
+    const unzip = new Unzip(entry => {
+      toAwait.push(new Promise<void>((resolve, reject) => {
+        const chunks = [];
+        entry.ondata = (err, chunk, final) => {
+          if (err) reject(err);
+          chunks.push(chunk);
+          if (final) {
+            result[entry.name] = mergeChunks(chunks);
+            resolve();
+          }
+        };
+        entry.start();
+      }));
+    });
+    unzip.register(Decoder);
+    unzip.push(zipArchive, true);
+    await Promise.all(toAwait);
+    resolve(result);
+  });
+}


### PR DESCRIPTION
Resolves #229 

---

Add support for automatic generation of `Zip64 end of central directory record` and `Zip64 end of central directory locator` when bytes available in standard `End of central directory record` are not enough. 

Zip64 EOCD will be added when when at least one of the following is true:
1\. total number of files in .zip archive is greater than 65,535
2\. size of the central directory is greater than 4,294,967,295 bytes (4GB)
3\. central directory offset is greater than 4,294,967,295 bytes (4GB)

---

Add support for automatic generation of `Zip64 Extended Information Extra Field` when bytes available in standard `local file header` or `central directory file header` are not enough. 

Zip64 Extra Field with 2 fields will be added to `local file header` when:
1\. file uncompressed/original size is greater than 4,294,967,295 bytes (4GB) or
2\. file compressed size is greater than 4,294,967,295 bytes (4GB)

Zip64 Extra Field with 1,2 or 3 fields will be added to `central directory file header` when:
1\. file uncompressed/original size is greater than 4,294,967,295 bytes (4GB) [1 field or more]
2\. file compressed size is greater than 4,294,967,295 bytes (4GB) [2 fields or more]
3\. local file header offset is greater than 4,294,967,295 bytes (4GB) [3 fields]

---

Add support for `Data descriptors` in Zip64 format activated by a new special flag `zip64`.

For file streams with this flag, an empty Zip64 Extra Field with 0 fields will be added to `local file header` and then, at the end of the file stream, a Data Descriptor in Zip64 format. 

---


Other changes:

1. Read values from Zip64 Extra Field (if it is present) even if there is no Zip64 EOCD in the zip archive. Currently Zip64 EFs are ignored when Zip64 EOCD is not found in the file. 
2. Take into account that the Zip64 EF can have different lengths, 0,8,16,24+. Currently Zip64 EF is assumed to have at least 2 fields (length >= 16 bytes).
3. Fix for inconsistent `mtime` generated during zip stream. Currently, if the time between adding a file to the archive `zip.add(myFile)` and ending the stream `zip.end()` is greater than a few seconds, the `mtime` in the Local File Header differs from the `mtime` of the Central Directory Header. Assuming that the user has not defined `myFile.mtime = some date`.
4. Prevent adding Data Descriptor for files added in one go `zip.add(myFile), myFile.push(strToU8('the end'), true)`. Currently, during the zip stream, the Data Descriptor is added to every file in the archive even though this is not always necessary, and as a result it increases the final size of the zip file as well as making it more difficult to read from the stream later.
5. Separate the code needed only for streaming from the code executed by the `zipSync` and `zip (async)` functions.  Regarding the creation of the zip file header.
