### PR TITLE
fix(docs): Not yet Supports files up to 4GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ In addition to the base decompression and compression APIs, `fflate` supports hi
 | ZIP support                 | ❌     | ❌                      | ✅                    | ✅                             |
 | Streaming support           | ✅     | ❌                      | ❌                    | ✅                             |
 | GZIP support                | ✅     | ❌                      | ❌                    | ✅                             |
-| Supports files up to 4GB    | ✅     | ❌                      | ❌                    | ❌                             |
 | Doesn't hang on error       | ✅     | ❌                      | ❌                    | ✅                             |
 | Dictionary support          | ✅     | ❌                      | ❌                    | ✅                             |
 | Multi-thread/Asynchronous   | ❌     | ❌                      | ❌                    | ✅                             |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In addition to the base decompression and compression APIs, `fflate` supports hi
 | ZIP support                 | ❌     | ❌                      | ✅                    | ✅                             |
 | Streaming support           | ✅     | ❌                      | ❌                    | ✅                             |
 | GZIP support                | ✅     | ❌                      | ❌                    | ✅                             |
-| Supports files up to 4GB    | ✅     | ❌                      | ❌                    | ✅                             |
+| Supports files up to 4GB    | ✅     | ❌                      | ❌                    | ❌                             |
 | Doesn't hang on error       | ✅     | ❌                      | ❌                    | ✅                             |
 | Dictionary support          | ✅     | ❌                      | ❌                    | ✅                             |
 | Multi-thread/Asynchronous   | ❌     | ❌                      | ❌                    | ✅                             |


### PR DESCRIPTION
README claimed that "Supports files up to 4GB", but this is factually incorrect because zip64 support has not yet been implemented - see #230 